### PR TITLE
Upgraded eiffel-remrem-parent version from 0.0.8 to 1.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+- Upgraded eiffel-remrem-parent version from 0.0.8 to 1.0.0.
+- Upgraded eiffel-remrem-protocol-interface version from 0.0.14 to 1.0.0.
+
 ## 0.5.3
 - Upgraded eiffel-remrem-parent version from 0.0.7 to 0.0.8.
 - Upgraded eiffel-remrem-protocol-interface version from 0.0.13 to 0.0.14.

--- a/pom.xml
+++ b/pom.xml
@@ -4,10 +4,10 @@
     <parent>
         <groupId>com.github.Ericsson</groupId>
         <artifactId>eiffel-remrem-parent</artifactId>
-        <version>0.0.8</version>
+        <version>1.0.0</version>
     </parent>
     <artifactId>eiffel-remrem-semantics</artifactId>
-    <version>0.5.3</version>
+    <version>1.0.0</version>
     <packaging>jar</packaging>
     <properties>
         <eclipse.jgit.version>5.0.1.201806211838-r</eclipse.jgit.version>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.github.Ericsson</groupId>
             <artifactId>eiffel-remrem-protocol-interface</artifactId>
-            <version>0.0.14</version>
+            <version>1.0.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Upgraded eiffel-remrem components version 
Upgraded eiffel-remrem-parent version from 0.0.8 to 1.0.0.
Upgraded eiffel-remrem-protocol-interface version from 0.0.14 to 1.0.0.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
