### PR TITLE
Add the link types FAILED_ISSUE, INCONCLUSIVE_ISSUE and SUCCESS…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.7
+- Added the link types FAILED_ISSUE,INCONCLUSIVE_ISSUE and SUCCESSFUL_ISSUE in IssueVerified event.
+
 ## 2.0.6
 - Uplifted eiffel-remrem-parent version from 2.0.1 to 2.0.2.
 - Uplifted eiffel-remrem-protocol-interface version from 2.0.1 to 2.0.2.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <version>2.0.2</version>
     </parent>
     <artifactId>eiffel-remrem-semantics</artifactId>
-    <version>2.0.6</version>
+    <version>2.0.7</version>
     <packaging>jar</packaging>
     <properties>
         <eclipse.jgit.version>5.0.1.201806211838-r</eclipse.jgit.version>

--- a/src/main/resources/linksValidation.properties
+++ b/src/main/resources/linksValidation.properties
@@ -35,7 +35,7 @@ EiffelFlowContextDefinedEvent.requiredLinks=
 EiffelFlowContextDefinedEvent.optionalLinks=CAUSE,CONTEXT,FLOW_CONTEXT
 
 EiffelIssueVerifiedEvent.requiredLinks=IUT
-EiffelIssueVerifiedEvent.optionalLinks=CAUSE,CONTEXT,FLOW_CONTEXT,ENVIRONMENT,VERIFICATION_BASIS
+EiffelIssueVerifiedEvent.optionalLinks=CAUSE,CONTEXT,FLOW_CONTEXT,ENVIRONMENT,VERIFICATION_BASIS,SUCCESSFUL_ISSUE,FAILED_ISSUE,INCONCLUSIVE_ISSUE
 
 EiffelSourceChangeCreatedEvent.requiredLinks=
 EiffelSourceChangeCreatedEvent.optionalLinks=CAUSE,CONTEXT,FLOW_CONTEXT,PREVIOUS_VERSION,BASE

--- a/src/test/resources/input/IssueVerified.json
+++ b/src/test/resources/input/IssueVerified.json
@@ -54,6 +54,18 @@
     {
       "type": "ENVIRONMENT",
       "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee4"
+    },
+    {
+      "type": "SUCCESSFUL_ISSUE",
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee5"
+    },
+    {
+      "type": "FAILED_ISSUE",
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee6"
+    },
+    {
+      "type": "INCONCLUSIVE_ISSUE",
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee7"
     }]
   }
 }

--- a/src/test/resources/output/IssueVerified.json
+++ b/src/test/resources/output/IssueVerified.json
@@ -50,6 +50,18 @@
     {
       "type": "ENVIRONMENT",
       "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee4"
+    },
+    {
+      "type": "SUCCESSFUL_ISSUE",
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee5"
+    },
+    {
+      "type": "FAILED_ISSUE",
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee6"
+    },
+    {
+      "type": "INCONCLUSIVE_ISSUE",
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee7"
     }
   ]
 }


### PR DESCRIPTION
…FUL_ISSUE in IssueVerified event.

Fixes https://github.com/eiffel-community/eiffel-remrem-semantics/issues/120

**Description of the Change**

The IssueVerifiedEvent was missing support for link types FAILED_ISSUE, INCONCLUSIVE_ISSUE and SUCCESS_ISSUE.
Now added the link types FAILED_ISSUE, INCONCLUSIVE_ISSUE and SUCCESS_ISSUE in IssueVerifiedEvent.

