### PR TITLE
REMReM should accept both a CONTEXT and a CAUSE links in the same event.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.13
+- Removed changes for REMReM should accept both a CONTEXT and a CAUSE links in the same event.
+
 ## 2.0.12
 - Added link types PARTIALLY_RESOLVED_ISSUE, RESOLVED_ISSUE and DERESOLVED_ISSUE in EiffelSourceChangeCreatedEvent.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 2.0.13
-- Removed changes for REMReM should accept both a CONTEXT and a CAUSE links in the same event.
+- Removed the validation of REMReM should not accept both a CAUSE and a CONTEXT link types in the same event.
 
 ## 2.0.12
 - Added link types PARTIALLY_RESOLVED_ISSUE, RESOLVED_ISSUE and DERESOLVED_ISSUE in EiffelSourceChangeCreatedEvent.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <version>2.0.4</version>
     </parent>
     <artifactId>eiffel-remrem-semantics</artifactId>
-    <version>2.0.12</version>
+    <version>2.0.13</version>
     <packaging>jar</packaging>
     <properties>
         <eclipse.jgit.version>5.0.1.201806211838-r</eclipse.jgit.version>

--- a/src/main/java/com/ericsson/eiffel/remrem/semantics/validator/EiffelValidator.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/semantics/validator/EiffelValidator.java
@@ -116,8 +116,6 @@ public class EiffelValidator {
     public void customValidation(JsonObject jsonObjectInput) throws EiffelValidationException {
         // Links validation
         Map<String, Integer> linksCountMapForEvent = new HashMap<String, Integer>();
-        String CAUSE_LINK = "CAUSE";
-        String CONTEXT_LINK = "CONTEXT";
         try {
             JsonArray links = jsonObjectInput.get("links").getAsJsonArray();
             for (JsonElement link : links) {
@@ -140,10 +138,6 @@ public class EiffelValidator {
                             "Multiple trace links are not allowed for link type " + requiredLinkType);
                 }
                 linksSet.remove(requiredLinkType);
-            }
-            if (linksCountMapForEvent.containsKey(CAUSE_LINK) && linksCountMapForEvent.containsKey(CONTEXT_LINK)) {
-                throw new EiffelValidationException(
-                        "Link types " + CAUSE_LINK + " and " + CONTEXT_LINK + " should not be in one event");
             }
             for (String optionalLinkType : optionalLinkTypes) {
                 Integer count = linksCountMapForEvent.get(optionalLinkType);

--- a/src/test/java/com/ericsson/eiffel/remrem/semantics/ValidationTest.java
+++ b/src/test/java/com/ericsson/eiffel/remrem/semantics/ValidationTest.java
@@ -63,5 +63,21 @@ public class ValidationTest {
         
     }
 
-    
+    @Test
+    public void TestEventwithCauseAndContextLinkTypes() throws Exception {
+        try {
+            File file = new File("output/TriggeredwithCauseAndContext.json");
+            if (file.exists()) {
+                JsonObject object = parser.parse(new FileReader(file)).getAsJsonObject();
+                String msgType = object.get("meta").getAsJsonObject().get("type").getAsString();
+                EiffelValidator validator = EiffelOutputValidatorFactory
+                        .getEiffelValidator(EiffelEventType.fromString(msgType));
+                validator.validate(object);
+                validator.customValidation(object);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.assertFalse(true);
+        }
+    }
 }

--- a/src/test/resources/output/TriggeredwithCauseAndContext.json
+++ b/src/test/resources/output/TriggeredwithCauseAndContext.json
@@ -1,0 +1,52 @@
+{
+  "meta": {
+    "id": "2dd2d13f-e3e5-4fac-80e3-ef4537985009",
+    "type": "EiffelActivityTriggeredEvent",
+    "version": "4.0.0",
+    "time": 1554389013770,
+    "tags": ["product_development","product_feature1"],
+    "source": {
+      "domainId": "eiffeltest",
+      "host": "localhost",
+      "name": "LOCALHOST",
+      "serializer": "pkg:maven/com.github.eiffel-community/eiffel-remrem-semantics@2.0.2",
+      "uri": "https://localhost:8080/jenkins/job"
+    }
+  },
+  "data": {
+    "name": "ActivityTrigger",
+    "categories": [
+      "First",
+      "second"
+    ],
+    "triggers": [
+      {
+        "type": "MANUAL",
+        "description": "Started by user anonymous"
+      },
+      {
+        "type": "SOURCE_CHANGE",
+        "description": "Change"
+      }
+    ],
+    "customData": [
+      {
+        "key": "EIFFERVERSION",
+        "value": "eiffel2.0"
+      },
+      {
+        "key": "FLOWCONTEXT",
+        "value": "master"
+      }
+    ]
+  },
+  "links": [
+    {
+      "type": "CAUSE",
+      "target": "e269b37d-17a1-4a10-aafb-c108735ee51f"
+    },    {
+      "type": "CONTEXT",
+      "target": "e269b37d-17a1-4a10-aafb-c108735ee52e"
+    }
+  ]
+}


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests.
-->

### Applicable Issues
https://github.com/eiffel-community/eiffel-remrem-generate/issues/164

### Description of the Change
Removed the validation of REMReM should not accept both a CAUSE and a CONTEXT link types in the same event

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
REMReM should accept both a CONTEXT and a CAUSE links in the same event.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
