### PR TITLE
Added lenientValidation support to REMReM generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.14
+- REMReM Generate defination for supported Eiffel protocols updated for support Lenient Validation.
+
 ## 2.0.13
 - Removed the validation of REMReM should not accept both a CAUSE and a CONTEXT link types in the same event.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 2.1.0
-- Updated REMReM Generate to support lenient validation for Eiffel Protocol.
+- Updated REMReM Generate to support lenient validation for Eiffel Semantics protocol.
 
 ## 2.0.13
 - Removed the validation of REMReM should not accept both a CAUSE and a CONTEXT link types in the same event.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## 2.0.14
-- REMReM Generate defination for supported Eiffel protocols updated for support Lenient Validation.
+## 2.1.0
+- Updated REMReM Generate to support lenient validation for Eiffel Protocol.
 
 ## 2.0.13
 - Removed the validation of REMReM should not accept both a CAUSE and a CONTEXT link types in the same event.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <version>2.0.4</version>
     </parent>
     <artifactId>eiffel-remrem-semantics</artifactId>
-    <version>2.0.14</version>
+    <version>2.1.0</version>
     <packaging>jar</packaging>
     <properties>
         <eclipse.jgit.version>5.0.1.201806211838-r</eclipse.jgit.version>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.github.eiffel-community</groupId>
             <artifactId>eiffel-remrem-protocol-interface</artifactId>
-            <version>2.0.5</version>
+            <version>2.1.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <version>2.0.4</version>
     </parent>
     <artifactId>eiffel-remrem-semantics</artifactId>
-    <version>2.0.13</version>
+    <version>2.0.14</version>
     <packaging>jar</packaging>
     <properties>
         <eclipse.jgit.version>5.0.1.201806211838-r</eclipse.jgit.version>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.github.eiffel-community</groupId>
             <artifactId>eiffel-remrem-protocol-interface</artifactId>
-            <version>2.0.4</version>
+            <version>2.0.5</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -66,6 +66,11 @@
             <artifactId>org.eclipse.jgit.archive</artifactId>
             <version>${eclipse.jgit.version}</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+        <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>2.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/main/java/com/ericsson/eiffel/remrem/semantics/SemanticsService.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/semantics/SemanticsService.java
@@ -185,7 +185,6 @@ public class SemanticsService implements MsgService {
         eventTypes.put(ALERT_CEASED, EiffelAlertCeasedEvent.class);
         eventTypes.put(ALERT_RAISED, EiffelAlertRaisedEvent.class);
         eventTypes.put(ISSUE_DEFINED, EiffelIssueDefinedEvent.class);
-
         return eventTypes;
     }
 
@@ -193,7 +192,7 @@ public class SemanticsService implements MsgService {
     public String generateMsg(String msgType, JsonObject bodyJson) {
         return generateMsg(msgType, bodyJson, false);
     }
-    
+
     @Override
     public String generateMsg(String msgType, JsonObject bodyJson, Boolean lenientValidation) {
         try {
@@ -207,7 +206,6 @@ public class SemanticsService implements MsgService {
                 return createErrorResponse(msgType, supportedEventTypes);
             }
             Class<? extends Event> eventType = eventTypes.get(eiffelType);
-
             JsonObject msgNodes = null;
             JsonObject eventNodes = null;
             if (bodyJson.get(MSG_PARAMS) != null && bodyJson.get(EVENT_PARAMS) != null
@@ -235,9 +233,7 @@ public class SemanticsService implements MsgService {
                 return createErrorResponse(eiffelType.getEventName(),
                         "Mismatch of eventype in request query parameter with property 'type' in the input json message");
             }
-
             Event event = eventCreation(eventType, msgNodes, eventNodes);
-
             String result = gson.toJson(event);
             JsonObject outputValidate = outputValidate(eiffelType, result, lenientValidation);
             return gson.toJson(outputValidate);
@@ -290,6 +286,11 @@ public class SemanticsService implements MsgService {
     }
 
     @Override
+    public ValidationResult validateMsg(String msgType, JsonObject jsonvalidateMessage) {
+        return validateMsg(msgType, jsonvalidateMessage, false);
+    }
+
+    @Override
     public ValidationResult validateMsg(String msgType, JsonObject jsonvalidateMessage, Boolean lenientValidation) {
         ValidationResult validationResult = null;
         EiffelEventType eiffelType = EiffelEventType.fromString(msgType);
@@ -302,6 +303,7 @@ public class SemanticsService implements MsgService {
         }
         return validationResult;
     }
+
     @Override
     public String getEventId(JsonObject json) {
         if (json.isJsonObject() && json.getAsJsonObject().has(META)
@@ -331,7 +333,7 @@ public class SemanticsService implements MsgService {
         }
         return null;
     }
-    
+
     @Override
     public Collection<String> getSupportedEventTypes() {
         return supportedEventTypes;
@@ -399,8 +401,6 @@ public class SemanticsService implements MsgService {
     public String getServiceName() {
         return EIFFELSEMANTICS;
     }
-
-    
 
     /**
      * Returns the domain Id from json formatted eiffel message.

--- a/src/main/java/com/ericsson/eiffel/remrem/semantics/validator/EiffelValidator.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/semantics/validator/EiffelValidator.java
@@ -20,6 +20,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.xml.bind.ValidationException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -33,16 +37,29 @@ import com.github.fge.jsonschema.core.report.ProcessingMessage;
 import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.main.JsonSchema;
 import com.github.fge.jsonschema.main.JsonSchemaFactory;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
 
 public class EiffelValidator {
+    
+    private static final String REGEX_PATH = "\\/\\d*";
+    private static final String CUSTOM_DATA = "customData";
+    private static final String SLASH = "/";
+    private static final String DOT = ".";
+    private static final String REMREM_GENERATE_FAILURES = "remremGenerateFailures";
+    private static final String PATH2 = "path";
+    private static final String MESSAGE2 = "message";
+    private static final String TYPE2 = "type";
+    private static final String REQUIRED = "required";
+    private static final String POINTER = "pointer";
+    private static final String INSTANCE = "instance";
+    private static final String KEYWORD = "keyword";
     public static final Logger log = LoggerFactory.getLogger(EiffelValidator.class);
-
+    private static final String DATA = "data";
     private JsonSchema validationSchema;
     private String schemaResourceName;
     private String eventType;
@@ -72,20 +89,112 @@ public class EiffelValidator {
             throw new IllegalArgumentException(message, e);
         }
     }
-
-    public void validate(JsonObject jsonObjectInput) throws EiffelValidationException {
+    public JsonObject validate(JsonObject jsonObjectInput) throws EiffelValidationException {
+        return validate(jsonObjectInput, false);
+    }
+    
+    public JsonObject validate(JsonObject jsonObjectInput, Boolean lenientValidation) throws EiffelValidationException {
+        JsonArray remremGenerateFailures = new JsonArray();
         try {
-            ProcessingReport report = validationSchema.validate(JsonLoader.fromString(jsonObjectInput.toString()));
-            if (!report.isSuccess()) {
+            final ProcessingReport report = validationSchema.validate(JsonLoader.fromString(jsonObjectInput.toString()),
+                    true);
+            if (!report.isSuccess() && lenientValidation) {
+                log.debug("Trying to revalidate the json for optional fields");
                 log.warn(jsonObjectInput.toString());
+                String revalidatedJson = removeErrorProperties(report, jsonObjectInput, remremGenerateFailures);
+                ProcessingReport report2 = validationSchema.validate(JsonLoader.fromString(revalidatedJson), true);
+                if (!report2.isSuccess()) {
+                    throw new EiffelValidationException(getErrorsList(report2));
+                }
+                return addRemremGenerateFailuresToCustomData(new JsonParser().parse(revalidatedJson).getAsJsonObject(), remremGenerateFailures);
+            }
+            else if(!report.isSuccess()){
                 throw new EiffelValidationException(getErrorsList(report));
             }
             log.debug("VALIDATED. Schema used: {}", schemaResourceName);
+            return jsonObjectInput;
         } catch (Exception e) {
-            String message = "Cannot validate given JSON string";
+            final String message = "Cannot validate given JSON string";
             log.debug(message, e);
             throw new EiffelValidationException(message, e);
         }
+    }
+    /**
+     * removeErrorProperties for removing the validation failures from Eiffel event and list the validation failures
+     * @param report
+     * @param jsonObjectInput
+     * @param remremGenerateFailures
+     * @return
+     * @throws ValidationException
+     */
+    private String removeErrorProperties(ProcessingReport report, JsonObject jsonObjectInput, JsonArray remremGenerateFailures) throws EiffelValidationException {
+        JsonParser parser = new JsonParser();
+        DocumentContext doc = JsonPath.parse(jsonObjectInput.toString());
+        for (ProcessingMessage processingMessage : report) {
+            if (LogLevel.ERROR.equals(processingMessage.getLogLevel())) {
+                JsonElement element = parser.parse(processingMessage.asJson().toString());
+                if (element.getAsJsonObject().get(KEYWORD).getAsString().equals(REQUIRED)) {
+                    throw new EiffelValidationException(getErrorsList(report));
+                }
+                String errorPath = element.getAsJsonObject().get(INSTANCE).getAsJsonObject().get(POINTER)
+                        .getAsString();
+                JsonObject addValidationFailurs = addValidationFailurs(element, processingMessage.getMessage());
+                remremGenerateFailures.add(addValidationFailurs);
+                doc.delete(getPath(errorPath));
+            }
+        }
+        return doc.jsonString();
+    }
+    
+    /**
+     * getPath for create the DocumentContext path from validation failure path
+     * example 
+     * 1) meta/tags/0 --> $.meta.tags[0]
+     * 2) links/0/target --> $.links[0]
+     * 3) /data/outcome/conclusion --> $.data.outcome.conclusion
+     * @param errorPath
+     * @return path
+     */
+    private String getPath(String errorPath) {
+        final Pattern pattern = Pattern.compile(REGEX_PATH, Pattern.MULTILINE);
+        final Matcher matcher = pattern.matcher(errorPath);
+        while (matcher.find()) {
+            if(matcher.group(0).length()>1) {
+                errorPath = errorPath.substring(0, errorPath.indexOf(matcher.group(0))+matcher.group(0).length());
+                errorPath = errorPath.replaceAll(matcher.group(0), "["+matcher.group(0).substring(1)+"]");
+            }
+        }
+        return "$" + errorPath.replace(SLASH, DOT);
+    }
+    private JsonObject addValidationFailurs(JsonElement element, String message) {
+        log.debug("Adding the error field information to the array");
+        String type = element.getAsJsonObject().get(KEYWORD).getAsString();
+        String path = element.getAsJsonObject().get(INSTANCE).getAsJsonObject().get(POINTER).getAsString();
+        JsonObject object = new JsonObject();
+        object.addProperty(TYPE2, type);
+        object.addProperty(MESSAGE2, message);
+        object.addProperty(PATH2, path);
+        return object;
+    }
+    private JsonObject addRemremGenerateFailuresToCustomData(JsonObject inputJson, JsonArray remremGenerateFailures) {
+        JsonArray customData = getCustomData(inputJson);
+        JsonObject object = new JsonObject();
+        object.add(REMREM_GENERATE_FAILURES, remremGenerateFailures);
+        customData.add(object);
+        return inputJson;
+    }
+    
+    /**
+     * for get the customData json array from Gen2 Eiffel message.
+     * @param json
+     * @return
+     */
+    public JsonArray getCustomData(JsonObject json) {
+        if (json.isJsonObject() && json.getAsJsonObject().has(DATA)
+                && json.getAsJsonObject().getAsJsonObject(DATA).has(CUSTOM_DATA)) {
+            return json.getAsJsonObject().getAsJsonObject(DATA).get(CUSTOM_DATA).getAsJsonArray();
+        }
+        return null;
     }
 
     /**
@@ -93,20 +202,14 @@ public class EiffelValidator {
      * @param report json validation report
      * @return error message
      */
-    private String getErrorsList(ProcessingReport report) {
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        JsonParser parser = new JsonParser();
-        String message = "";
-        for (ProcessingMessage processingMessage : report) {
-            if(LogLevel.ERROR.equals(processingMessage.getLogLevel())) {
-                JsonElement element=parser.parse(processingMessage.asJson().toString());
-                element.getAsJsonObject().remove("schema");
-                element.getAsJsonObject().remove("level");
-                message = gson.toJson(element);
-                log.debug(message);
+    private String getErrorsList(final ProcessingReport report) {
+        List<String> messages = new ArrayList<String>();
+        for (final ProcessingMessage processingMessage : report) {
+            if (LogLevel.ERROR.equals(processingMessage.getLogLevel())) {
+                messages.add(processingMessage.getMessage().toString());
             }
         }
-        return message;
+        return messages.toString();
     }
     /**
      * This method is used to validate links in an event

--- a/src/main/java/com/ericsson/eiffel/remrem/semantics/validator/EiffelValidator.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/semantics/validator/EiffelValidator.java
@@ -44,13 +44,13 @@ import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 
 public class EiffelValidator {
-    
+
     private static final String REGEX_PATH = "\\/\\d*";
     private static final String CUSTOM_DATA = "customData";
     private static final String SLASH = "/";
     private static final String DOT = ".";
     private static final String REMREM_GENERATE_FAILURES = "remremGenerateFailures";
-    private static final String PATH2 = "path";
+    private static final String PATH = "path";
     private static final String MESSAGE = "message";
     private static final String TYPE = "type";
     private static final String REQUIRED = "required";
@@ -88,10 +88,11 @@ public class EiffelValidator {
             throw new IllegalArgumentException(message, e);
         }
     }
+
     public JsonObject validate(JsonObject jsonObjectInput) throws EiffelValidationException {
         return validate(jsonObjectInput, false);
     }
-    
+
     public JsonObject validate(JsonObject jsonObjectInput, Boolean lenientValidation) throws EiffelValidationException {
         JsonArray remremGenerateFailures = new JsonArray();
         log.debug("VALIDATING Schema used: {}", schemaResourceName);
@@ -116,13 +117,13 @@ public class EiffelValidator {
             throw new EiffelValidationException(message, e);
         }
     }
+
     private void handleErrorReport(JsonObject jsonObjectInput, ProcessingReport report) throws EiffelValidationException {
         if (!report.isSuccess()) {
-            log.error("Eiffel message validation failed");
-            log.error(jsonObjectInput.toString());
             throw new EiffelValidationException(getErrorsList(report));
         }
     }
+
     /**
      * removeErrorProperties for removing the validation failures from Eiffel event and list the validation failures
      * @param report
@@ -149,7 +150,7 @@ public class EiffelValidator {
         }
         return doc.jsonString();
     }
-    
+
     /**
      * getPath for create the DocumentContext path from validation failure path
      * example 
@@ -170,6 +171,7 @@ public class EiffelValidator {
         }
         return "$" + errorPath.replace(SLASH, DOT);
     }
+
     private JsonObject addValidationFailures(JsonElement element, String message) {
         log.debug("Adding the error field information to the array");
         String type = element.getAsJsonObject().get(KEYWORD).getAsString();
@@ -177,18 +179,21 @@ public class EiffelValidator {
         JsonObject object = new JsonObject();
         object.addProperty(TYPE, type);
         object.addProperty(MESSAGE, message);
-        object.addProperty(PATH2, path);
+        object.addProperty(PATH, path);
         return object;
     }
+
     private JsonObject addRemremGenerateFailuresToCustomData(JsonObject inputJson, JsonArray remremGenerateFailures) {
-        JsonArray customData = getCustomData(inputJson);
-        JsonObject object = new JsonObject();
-        object.addProperty("key", REMREM_GENERATE_FAILURES);
-        object.add("value", remremGenerateFailures);
-        customData.add(object);
+        if (remremGenerateFailures.size() > 0) {
+            JsonArray customData = getCustomData(inputJson);
+            JsonObject object = new JsonObject();
+            object.addProperty("key", REMREM_GENERATE_FAILURES);
+            object.add("value", remremGenerateFailures);
+            customData.add(object);
+        }
         return inputJson;
     }
-    
+
     /**
      * Gets the customData array from an Eiffel message
      * @param Eiffel message
@@ -216,6 +221,7 @@ public class EiffelValidator {
         }
         return messages.toString();
     }
+
     /**
      * This method is used to validate links in an event
      * @param JsonArray of links in an event

--- a/src/main/java/com/ericsson/eiffel/remrem/semantics/validator/EiffelValidator.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/semantics/validator/EiffelValidator.java
@@ -51,8 +51,8 @@ public class EiffelValidator {
     private static final String DOT = ".";
     private static final String REMREM_GENERATE_FAILURES = "remremGenerateFailures";
     private static final String PATH2 = "path";
-    private static final String MESSAGE2 = "message";
-    private static final String TYPE2 = "type";
+    private static final String MESSAGE = "message";
+    private static final String TYPE = "type";
     private static final String REQUIRED = "required";
     private static final String POINTER = "pointer";
     private static final String INSTANCE = "instance";
@@ -137,7 +137,7 @@ public class EiffelValidator {
         for (ProcessingMessage processingMessage : report) {
             if (LogLevel.ERROR.equals(processingMessage.getLogLevel())) {
                 JsonElement element = parser.parse(processingMessage.asJson().toString());
-                if (element.getAsJsonObject().get(KEYWORD).getAsString().equals(REQUIRED)) {
+                if (element.getAsJsonObject().get(KEYWORD).getAsString().equals(REQUIRED) || element.getAsJsonObject().get(KEYWORD).getAsString().equals(TYPE)) {
                     throw new EiffelValidationException(getErrorsList(report));
                 }
                 String errorPath = element.getAsJsonObject().get(INSTANCE).getAsJsonObject().get(POINTER)
@@ -175,15 +175,16 @@ public class EiffelValidator {
         String type = element.getAsJsonObject().get(KEYWORD).getAsString();
         String path = element.getAsJsonObject().get(INSTANCE).getAsJsonObject().get(POINTER).getAsString();
         JsonObject object = new JsonObject();
-        object.addProperty(TYPE2, type);
-        object.addProperty(MESSAGE2, message);
+        object.addProperty(TYPE, type);
+        object.addProperty(MESSAGE, message);
         object.addProperty(PATH2, path);
         return object;
     }
     private JsonObject addRemremGenerateFailuresToCustomData(JsonObject inputJson, JsonArray remremGenerateFailures) {
         JsonArray customData = getCustomData(inputJson);
         JsonObject object = new JsonObject();
-        object.add(REMREM_GENERATE_FAILURES, remremGenerateFailures);
+        object.addProperty("key", REMREM_GENERATE_FAILURES);
+        object.add("value", remremGenerateFailures);
         customData.add(object);
         return inputJson;
     }

--- a/src/main/java/com/ericsson/eiffel/remrem/semantics/validator/EiffelValidator.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/semantics/validator/EiffelValidator.java
@@ -142,7 +142,7 @@ public class EiffelValidator {
                 }
                 String errorPath = element.getAsJsonObject().get(INSTANCE).getAsJsonObject().get(POINTER)
                         .getAsString();
-                JsonObject addValidationFailurs = addValidationFailurs(element, processingMessage.getMessage());
+                JsonObject addValidationFailurs = addValidationFailures(element, processingMessage.getMessage());
                 remremGenerateFailures.add(addValidationFailurs);
                 doc.delete(getPath(errorPath));
             }
@@ -170,7 +170,7 @@ public class EiffelValidator {
         }
         return "$" + errorPath.replace(SLASH, DOT);
     }
-    private JsonObject addValidationFailurs(JsonElement element, String message) {
+    private JsonObject addValidationFailures(JsonElement element, String message) {
         log.debug("Adding the error field information to the array");
         String type = element.getAsJsonObject().get(KEYWORD).getAsString();
         String path = element.getAsJsonObject().get(INSTANCE).getAsJsonObject().get(POINTER).getAsString();

--- a/src/test/java/com/ericsson/eiffel/remrem/semantics/ServiceTest.java
+++ b/src/test/java/com/ericsson/eiffel/remrem/semantics/ServiceTest.java
@@ -147,7 +147,7 @@ public class ServiceTest {
         ValidationResult msg = null;
         try {
             input = parser.parse(new FileReader(file)).getAsJsonObject();
-            msg = service.validateMsg(ACTIVITY_FINISHED, input);
+            msg = service.validateMsg(ACTIVITY_FINISHED, input, false);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -203,7 +203,7 @@ public class ServiceTest {
     
     @Test
     public void testGetSupportedEventTypes() {
-    	URL url = getClass().getClassLoader().getResource("EventTypes.json");
+        URL url = getClass().getClassLoader().getResource("EventTypes.json");
         String path = url.getPath().replace("%20", " ");
         File file = new File(path);
         JsonObject input = null;
@@ -214,9 +214,9 @@ public class ServiceTest {
             JsonArray eventTypes = input.getAsJsonArray("eventTypes");            
             List<String> matchingCollection = new ArrayList<>();
             if (eventTypes != null) {
-            	for (JsonElement event : eventTypes) {
-            		matchingCollection.add(event.getAsString());
-            	}
+                for (JsonElement event : eventTypes) {
+                    matchingCollection.add(event.getAsString());
+                }
             }
             checkValue = types.containsAll(matchingCollection);
         } catch (Exception e) {
@@ -251,6 +251,39 @@ public class ServiceTest {
             System.out.println("Exception occured while validating templates");
             e.printStackTrace();
             Assert.assertFalse(true);
+        }
+    }
+    
+    @Test
+    public void testInvalid_lv_Message_Success() {
+        try {
+            URL url = getClass().getClassLoader().getResource("invalid/lv_EiffelArtifactCreatedEventInvalid.json");
+            String path = url.getPath().replace("%20", " ");
+            File file = new File(path);
+            JsonObject input = parser.parse(new FileReader(file)).getAsJsonObject();
+            String msg = service.generateMsg("EiffelArtifactCreatedEvent", input, true);
+            Assert.assertTrue(msg.contains("remremGenerateFailures"));
+            Assert.assertTrue(msg.contains("data"));
+            Assert.assertTrue(msg.contains("meta"));
+            Assert.assertTrue(msg.contains("links"));
+        } catch (FileNotFoundException e) {
+            Assert.assertFalse(false);
+        }
+    }
+    @Test
+    public void testInvalid_lv_Message_fail() {
+        try {
+            URL url = getClass().getClassLoader().getResource("invalid/lv_EiffelArtifactCreatedEventInvalid.json");
+            String path = url.getPath().replace("%20", " ");
+            File file = new File(path);
+            JsonObject input = parser.parse(new FileReader(file)).getAsJsonObject();
+            String msg = service.generateMsg("EiffelArtifactCreatedEvent", input);
+            Assert.assertTrue(msg.contains("message"));
+            Assert.assertTrue(msg.contains("Cannot validate given JSON string"));
+            Assert.assertTrue(msg.contains("cause"));
+            Assert.assertTrue(msg.contains("ECMA 262 regex"));
+        } catch (FileNotFoundException e) {
+            Assert.assertFalse(false);
         }
     }
 }

--- a/src/test/java/com/ericsson/eiffel/remrem/semantics/ServiceTest.java
+++ b/src/test/java/com/ericsson/eiffel/remrem/semantics/ServiceTest.java
@@ -25,7 +25,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -61,9 +64,9 @@ public class ServiceTest {
     static String semanticsSerializer ;
 
     @BeforeClass
-    public static void readManifestGav() {
+    public static void readManifestGav() throws UnsupportedEncodingException {
         URL url = ServiceTest.class.getClassLoader().getResource("MANIFEST.MF");
-        String manifestPath = url.getPath().replace("%20", " ");
+        String manifestPath = URLDecoder.decode(url.getPath(), StandardCharsets.UTF_8.name());
         try {
             Manifest manifest = new Manifest(new FileInputStream(manifestPath));
             Attributes attributes1 = manifest.getMainAttributes();
@@ -106,26 +109,21 @@ public class ServiceTest {
     
 
     @Test
-    public void testUnknownMessage() {
-        try {
+    public void testUnknownMessage() throws UnsupportedEncodingException, JsonIOException, JsonSyntaxException, FileNotFoundException {
             URL url = getClass().getClassLoader().getResource("input/ArtifactPublished.json");
-            String path = url.getPath().replace("%20", " ");
+            String path = URLDecoder.decode(url.getPath(), StandardCharsets.UTF_8.name());
             File file = new File(path);
             JsonObject input = parser.parse(new FileReader(file)).getAsJsonObject();
             String msg = service.generateMsg("unknownmessage", input);
             Assert.assertTrue(msg.contains("message"));
             Assert.assertTrue(msg.contains("Unknown event type requested"));
             Assert.assertTrue(msg.contains("SUPPORTED_EVENT_TYPES"));
-        } catch (FileNotFoundException e) {
-            Assert.assertFalse(false);
-        }
     }
 
     @Test
-    public void testInvalidMessage() {
-        try {
+    public void testInvalidMessage() throws UnsupportedEncodingException, JsonIOException, JsonSyntaxException, FileNotFoundException {
             URL url = getClass().getClassLoader().getResource("invalid/ActivityFinishedInvalid.json");
-            String path = url.getPath().replace("%20", " ");
+            String path = URLDecoder.decode(url.getPath(), StandardCharsets.UTF_8.name());
             File file = new File(path);
             JsonObject input = parser.parse(new FileReader(file)).getAsJsonObject();
             String msg = service.generateMsg(ACTIVITY_FINISHED, input);
@@ -133,15 +131,12 @@ public class ServiceTest {
             Assert.assertTrue(msg.contains("Cannot validate given JSON string"));
             Assert.assertTrue(msg.contains("cause"));
             Assert.assertTrue(msg.contains("object has missing required properties"));
-        } catch (FileNotFoundException e) {
-            Assert.assertFalse(false);
-        }
     }
 
     @Test
-    public void validateMessage() {
+    public void validateMessage() throws UnsupportedEncodingException {
         URL url = getClass().getClassLoader().getResource("output/ActivityFinished.json");
-        String path = url.getPath().replace("%20", " ");
+        String path = URLDecoder.decode(url.getPath(), StandardCharsets.UTF_8.name());
         File file = new File(path);
         JsonObject input;
         ValidationResult msg = null;
@@ -156,9 +151,9 @@ public class ServiceTest {
     }
 
     @Test
-    public void testGetEventType() {
+    public void testGetEventType() throws UnsupportedEncodingException {
         URL url = getClass().getClassLoader().getResource("output/ActivityFinished.json");
-        String path = url.getPath().replace("%20", " ");
+        String path = URLDecoder.decode(url.getPath(), StandardCharsets.UTF_8.name());
         File file = new File(path);
         JsonObject input;
         String eventType = null;
@@ -172,9 +167,9 @@ public class ServiceTest {
     }
 
     @Test
-    public void testGenerateRoutingKey() {
+    public void testGenerateRoutingKey() throws UnsupportedEncodingException {
         URL url = getClass().getClassLoader().getResource("output/ActivityFinished.json");
-        String path = url.getPath().replace("%20", " ");
+        String path = URLDecoder.decode(url.getPath(), StandardCharsets.UTF_8.name());
         File file = new File(path);
         JsonObject input;
         String routingKey = null;
@@ -202,9 +197,9 @@ public class ServiceTest {
     }
     
     @Test
-    public void testGetSupportedEventTypes() {
+    public void testGetSupportedEventTypes() throws UnsupportedEncodingException {
         URL url = getClass().getClassLoader().getResource("EventTypes.json");
-        String path = url.getPath().replace("%20", " ");
+        String path = URLDecoder.decode(url.getPath(), StandardCharsets.UTF_8.name());
         File file = new File(path);
         JsonObject input = null;
         boolean checkValue = false;        
@@ -255,10 +250,9 @@ public class ServiceTest {
     }
     
     @Test
-    public void testInvalid_lv_Message_Success() {
-        try {
+    public void testInvalid_lv_Message_Success() throws JsonIOException, JsonSyntaxException, FileNotFoundException, UnsupportedEncodingException {
             URL url = getClass().getClassLoader().getResource("invalid/lv_EiffelArtifactCreatedEventInvalid.json");
-            String path = url.getPath().replace("%20", " ");
+            String path = URLDecoder.decode(url.getPath(), StandardCharsets.UTF_8.name());
             File file = new File(path);
             JsonObject input = parser.parse(new FileReader(file)).getAsJsonObject();
             String msg = service.generateMsg("EiffelArtifactCreatedEvent", input, true);
@@ -266,15 +260,11 @@ public class ServiceTest {
             Assert.assertTrue(msg.contains("data"));
             Assert.assertTrue(msg.contains("meta"));
             Assert.assertTrue(msg.contains("links"));
-        } catch (FileNotFoundException e) {
-            Assert.assertFalse(false);
-        }
     }
     @Test
-    public void testInvalid_lv_Message_fail() {
-        try {
+    public void testInvalid_lv_Message_fail() throws JsonIOException, JsonSyntaxException, FileNotFoundException, UnsupportedEncodingException {
             URL url = getClass().getClassLoader().getResource("invalid/lv_EiffelArtifactCreatedEventInvalid.json");
-            String path = url.getPath().replace("%20", " ");
+            String path = URLDecoder.decode(url.getPath(), StandardCharsets.UTF_8.name());
             File file = new File(path);
             JsonObject input = parser.parse(new FileReader(file)).getAsJsonObject();
             String msg = service.generateMsg("EiffelArtifactCreatedEvent", input);
@@ -282,8 +272,5 @@ public class ServiceTest {
             Assert.assertTrue(msg.contains("Cannot validate given JSON string"));
             Assert.assertTrue(msg.contains("cause"));
             Assert.assertTrue(msg.contains("ECMA 262 regex"));
-        } catch (FileNotFoundException e) {
-            Assert.assertFalse(false);
-        }
     }
 }

--- a/src/test/resources/invalid/lv_EiffelArtifactCreatedEventInvalid.json
+++ b/src/test/resources/invalid/lv_EiffelArtifactCreatedEventInvalid.json
@@ -4,7 +4,7 @@
       "type": "EiffelArtifactCreatedEvent",
       "version": "3.0.0",
       "tags": [
-        123,
+        "tag1",
         "tag2"
       ],
       "source": {

--- a/src/test/resources/invalid/lv_EiffelArtifactCreatedEventInvalid.json
+++ b/src/test/resources/invalid/lv_EiffelArtifactCreatedEventInvalid.json
@@ -1,0 +1,69 @@
+{
+  "msgParams": {
+    "meta": {
+      "type": "EiffelArtifactCreatedEvent",
+      "version": "3.0.0",
+      "tags": [
+        123,
+        "tag2"
+      ],
+      "source": {
+        "domainId": "domainID",
+        "host": "host",
+        "name": "name",
+        "uri": "http:\/\/java.sun.com\/j2se\/1.3\/",
+        "serializer":"pkg:maven"
+      },
+      "security": {
+          "authorIdentity": "test",
+          "encryptedDigest": "sample"
+      }
+    }
+  },
+  "eventParams": {
+    "data": {
+      "gav": {
+        "groupId": "G",
+        "artifactId": "A",
+        "version": "V"
+      },
+      "fileInformation": [{
+        "name":"name"
+      }],
+      "buildCommand": "trigger",
+      "requiresImplementation": "NONE",
+      "name": "event",
+      "dependsOn": [
+      ],
+      "implement": [
+        
+      ],
+      "identity":"pkg:abc",
+      "customData": [{
+          "key": "firstLog",
+          "value": "http:\/\/myHost.com\/firstLog"
+        },
+        {
+          "key": "otherLog",
+          "value": "http:\/\/myHost.com\/firstLog33"
+        }
+      ]
+    },
+    "links": [{
+      "type": "CAUSE",
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
+    },
+    {
+      "type": "PREVIOUS_VERSION",
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
+    },
+    {
+      "type": "COMPOSITION",
+      "target": "aaaaaaaa"
+    },
+    {
+      "type": "ENVIRONMENT",
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3"
+    }]
+  }
+}


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
https://github.com/eiffel-community/eiffel-remrem-generate/issues/171

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Added Lenient Validation support to REMReM Semantics protocol, The Lenient Validation will perform the only mandatory field validation and non-mandatory validation failures will place in Eiffel message as a new property(remremGenerateFailures)

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->
The REMReM generate validation will not fail on non-fetal Eiffel message field issues. This feature is an option to the user, the user can decide the enable/disable the Lenient Validation. By default it is disabled.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: @raja-maragani 