### PR TITLE
Update schemas to match the Paris edition of the protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.0
+- Updated schemas to match the Paris edition of the protocol.
+
 ## 2.1.1
 - Uplifted eiffel-remrem-parent version from 2.0.4 to 2.0.5.
 - Uplifted eiffel-remrem-protocol-interface version from 2.1.0 to 2.1.1.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <version>2.0.5</version>
     </parent>
     <artifactId>eiffel-remrem-semantics</artifactId>
-    <version>2.1.1</version>
+    <version>2.2.0</version>
     <packaging>jar</packaging>
     <properties>
         <eclipse.jgit.version>5.0.1.201806211838-r</eclipse.jgit.version>
@@ -116,7 +116,7 @@
                             <mainClass>com.ericsson.eiffel.remrem.semantics.clone.PrepareLocalEiffelSchemas</mainClass>
                             <arguments>
                                 <argument>https://github.com/eiffel-community/eiffel.git</argument>
-                                <argument>tags/edition-agen-1</argument>
+                                <argument>tags/edition-paris</argument>
                                 <argument>https://github.com/Ericsson/eiffel-operations-extension.git</argument>
                                 <argument>tags/edition-agen</argument>
                             </arguments>

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactPublishedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactPublishedEventMeta.java
@@ -47,7 +47,7 @@ public class EiffelArtifactPublishedEventMeta implements Meta
      */
     @SerializedName("version")
     @Expose
-    private EiffelArtifactPublishedEventMeta.Version version = EiffelArtifactPublishedEventMeta.Version.fromValue("3.0.0");
+    private EiffelArtifactPublishedEventMeta.Version version = EiffelArtifactPublishedEventMeta.Version.fromValue("3.1.0");
     /**
      * 
      * (Required)
@@ -201,8 +201,8 @@ public class EiffelArtifactPublishedEventMeta implements Meta
 
     public enum Version {
 
-        @SerializedName("3.0.0")
-        _3_0_0("3.0.0");
+        @SerializedName("3.1.0")
+        _3_1_0("3.1.0");
         private final String value;
         private final static Map<String, EiffelArtifactPublishedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelArtifactPublishedEventMeta.Version>();
 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelCompositionDefinedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelCompositionDefinedEventMeta.java
@@ -47,7 +47,7 @@ public class EiffelCompositionDefinedEventMeta implements Meta
      */
     @SerializedName("version")
     @Expose
-    private EiffelCompositionDefinedEventMeta.Version version = EiffelCompositionDefinedEventMeta.Version.fromValue("3.0.0");
+    private EiffelCompositionDefinedEventMeta.Version version = EiffelCompositionDefinedEventMeta.Version.fromValue("3.1.0");
     /**
      * 
      * (Required)
@@ -201,8 +201,8 @@ public class EiffelCompositionDefinedEventMeta implements Meta
 
     public enum Version {
 
-        @SerializedName("3.0.0")
-        _3_0_0("3.0.0");
+        @SerializedName("3.1.0")
+        _3_1_0("3.1.0");
         private final String value;
         private final static Map<String, EiffelCompositionDefinedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelCompositionDefinedEventMeta.Version>();
 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/Location.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/Location.java
@@ -21,6 +21,9 @@ import com.google.gson.annotations.SerializedName;
 
 public class Location {
 
+    @SerializedName("name")
+    @Expose
+    private String name;
     /**
      * 
      * (Required)
@@ -37,6 +40,14 @@ public class Location {
     @SerializedName("uri")
     @Expose
     private String uri;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
 
     /**
      * 

--- a/src/main/resources/schemas/input/EiffelArtifactPublishedEvent.json
+++ b/src/main/resources/schemas/input/EiffelArtifactPublishedEvent.json
@@ -24,9 +24,9 @@
         "version": {
           "type": "string",
           "enum": [
-            "3.0.0"
+            "3.1.0"
           ],
-          "default": "3.0.0"
+          "default": "3.1.0"
         },
         "time": {
           "type": "integer",
@@ -147,6 +147,9 @@
             "type": "object",
             "javaType": "com.ericsson.eiffel.semantics.events.Location",
             "properties": {
+              "name": {
+                "type": "string"
+              },
               "type": {
                 "type": "string",
                 "enum": [

--- a/src/main/resources/schemas/input/EiffelCompositionDefinedEvent.json
+++ b/src/main/resources/schemas/input/EiffelCompositionDefinedEvent.json
@@ -24,9 +24,9 @@
         "version": {
           "type": "string",
           "enum": [
-            "3.0.0"
+            "3.1.0"
           ],
-          "default": "3.0.0"
+          "default": "3.1.0"
         },
         "time": {
           "type": "integer",

--- a/src/test/resources/input/ArtifactPublished.json
+++ b/src/test/resources/input/ArtifactPublished.json
@@ -2,7 +2,7 @@
   "msgParams": {
     "meta": {
       "type": "EiffelArtifactPublishedEvent",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "tags": [
         "tag1",
         "tag2"
@@ -24,6 +24,7 @@
     "data": {
       "locations": [{
           "type": "ARTIFACTORY",
+          "name": "file1",
           "uri": "https:\/\/one.place"
         },
         {

--- a/src/test/resources/input/CompositionDefined.json
+++ b/src/test/resources/input/CompositionDefined.json
@@ -2,7 +2,7 @@
   "msgParams": {
     "meta": {
       "type": "EiffelCompositionDefinedEvent",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "tags": [
         "tag1",
         "tag2"

--- a/src/test/resources/output/ArtifactPublished.json
+++ b/src/test/resources/output/ArtifactPublished.json
@@ -2,7 +2,7 @@
   "meta": {
     "id": "ff2f8aae-692d-4906-a3a3-bd819d4769c3",
     "type": "EiffelArtifactPublishedEvent",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "time": 1554389528061,
     "tags": [
       "tag1",
@@ -26,6 +26,7 @@
     "locations": [
       {
         "type": "ARTIFACTORY",
+        "name": "file1",
         "uri": "https://one.place"
       },
       {

--- a/src/test/resources/output/CompositionDefined.json
+++ b/src/test/resources/output/CompositionDefined.json
@@ -2,7 +2,7 @@
   "meta": {
     "id": "9019c5d4-4647-479e-bb5e-0a0c597c115e",
     "type": "EiffelCompositionDefinedEvent",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "time": 1554389919067,
     "tags": [
       "tag1",


### PR DESCRIPTION
### Applicable Issues
Closes #130 

### Description of the Change
Updating schemas to the Paris edition effectively means stepping up ArtP and CD to v3.1.0, but only the former actually affects the schemas.

Some of the generated files that were present prior to this commit appear to have been modified after they were generated, i.e. regenerating them introduced various non-consequential changes (whitespace and/or line endings).

The copyright header in each file was retained though, although we should update the code that generates the files to keep the header. I've filed #133 for this.

### Alternate Designs
None.

### Benefits
Latest protocol edition available to REMReM users.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
