### PR TITLE
Make schema updates work on non-Windows platforms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>com.vdurmont</groupId>
+            <artifactId>semver4j</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.hk2.external</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>

--- a/src/main/java/com/ericsson/eiffel/remrem/semantics/clone/PrepareLocalEiffelSchemas.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/semantics/clone/PrepareLocalEiffelSchemas.java
@@ -23,6 +23,8 @@ import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.SocketAddress;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -64,17 +66,17 @@ public class PrepareLocalEiffelSchemas {
      * @param localEiffelRepoPath
      *            destination path to clone the repo.
      */
-    private void cloneEiffelRepo(final String repoURL, final String branch, final File localEiffelRepoPath) {
+    private void cloneEiffelRepo(final String repoURL, final String branch, final Path localEiffelRepoPath) {
         Git localGitRepo = null;
         
         // checking for repository exists or not in the localEiffelRepoPath
         try {
-            if (!localEiffelRepoPath.exists()) {
+            if (Files.notExists(localEiffelRepoPath)) {
                 // cloning github repository by using URL and branch name into local
-                localGitRepo = Git.cloneRepository().setURI(repoURL).setBranch("master").setDirectory(localEiffelRepoPath).call();
+                localGitRepo = Git.cloneRepository().setURI(repoURL).setBranch("master").setDirectory(localEiffelRepoPath.toFile()).call();
             } else {
                 // If required repository already exists
-                localGitRepo = Git.open(localEiffelRepoPath);
+                localGitRepo = Git.open(localEiffelRepoPath.toFile());
 
                 // Reset to normal if uncommitted changes are present
                 localGitRepo.reset().call();
@@ -152,12 +154,12 @@ public class PrepareLocalEiffelSchemas {
      * @param eiffelRepoPath
      *            local eiffel repository url
      */
-    private void copyOperationSchemas(final String operationsRepoPath, final String eiffelRepoPath) {
-        final File operationSchemas = new File(operationsRepoPath + File.separator + EiffelConstants.SCHEMA_LOCATION);
-        final File eiffelSchemas = new File(eiffelRepoPath + File.separator + EiffelConstants.SCHEMA_LOCATION);
-        if (operationSchemas.isDirectory()) {
+    private void copyOperationSchemas(final Path operationsRepoPath, final Path eiffelRepoPath) {
+        final Path operationSchemas = operationsRepoPath.resolve(EiffelConstants.SCHEMA_LOCATION);
+        final Path eiffelSchemas = eiffelRepoPath.resolve(EiffelConstants.SCHEMA_LOCATION);
+        if (Files.isDirectory(operationSchemas)) {
             try {
-                FileUtils.copyDirectory(operationSchemas, eiffelSchemas);
+                FileUtils.copyDirectory(operationSchemas.toFile(), eiffelSchemas.toFile());
             } catch (IOException e) {
                 System.out.println("Exception occurred while copying schemas from operations repository to eiffel repository");
                 e.printStackTrace();
@@ -176,9 +178,8 @@ public class PrepareLocalEiffelSchemas {
         final String operationRepoUrl = args[2];
         final String operationRepoBranch = args[3];
 
-        final File localEiffelRepoPath = new File(System.getProperty(EiffelConstants.USER_HOME) + File.separator + EiffelConstants.EIFFEL);
-        final File localOperationsRepoPath = new File(
-                System.getProperty(EiffelConstants.USER_HOME) + File.separator + EiffelConstants.OPERATIONS_REPO_NAME);
+        final Path localEiffelRepoPath = EiffelConstants.USER_HOME.resolve(EiffelConstants.EIFFEL);
+        final Path localOperationsRepoPath = EiffelConstants.USER_HOME.resolve(EiffelConstants.OPERATIONS_REPO_NAME);
 
         // Clone Eiffel Repo from GitHub 
         prepareLocalSchema.cloneEiffelRepo(eiffelRepoUrl, eiffelRepoBranch, localEiffelRepoPath);
@@ -187,7 +188,7 @@ public class PrepareLocalEiffelSchemas {
         prepareLocalSchema.cloneEiffelRepo(operationRepoUrl, operationRepoBranch, localOperationsRepoPath);
 
         //Copy operations repo Schemas to location where Eiffel repo schemas available
-        prepareLocalSchema.copyOperationSchemas(localOperationsRepoPath.getAbsolutePath(), localEiffelRepoPath.getAbsolutePath());
+        prepareLocalSchema.copyOperationSchemas(localOperationsRepoPath.toAbsolutePath(), localEiffelRepoPath.toAbsolutePath());
 
         // Read and Load JsonSchemas from Cloned Directory 
         final LocalRepo localRepo = new LocalRepo(localEiffelRepoPath);

--- a/src/main/java/com/ericsson/eiffel/remrem/semantics/clone/PrepareLocalEiffelSchemas.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/semantics/clone/PrepareLocalEiffelSchemas.java
@@ -14,7 +14,6 @@
 */
 package com.ericsson.eiffel.remrem.semantics.clone;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.Authenticator;
 import java.net.InetSocketAddress;
@@ -25,10 +24,10 @@ import java.net.SocketAddress;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.ResourceBundle;
 
 import org.apache.commons.io.FileUtils;
@@ -194,18 +193,12 @@ public class PrepareLocalEiffelSchemas {
         final LocalRepo localRepo = new LocalRepo(localEiffelRepoPath);
         localRepo.readSchemas();
 
-        final ArrayList<String> jsonEventNames = localRepo.getJsonEventNames();
-        final ArrayList<File> jsonEventSchemas = localRepo.getJsonEventSchemas();
-
-        // Schema changes 
+        // Schema changes
         final SchemaFile schemaFile = new SchemaFile();
 
-        // Iterate the Each jsonSchema file to Add and Modify the necessary properties 
-        if (jsonEventNames != null && jsonEventSchemas != null) {
-            for (int i = 0; i < jsonEventNames.size(); i++) {
-                schemaFile.modify(jsonEventSchemas.get(i), jsonEventNames.get(i));
-            }
+        // Iterate over available input schemas and create new and patched files
+        for (Map.Entry<String, Path> event : localRepo.getJsonEventSchemas().entrySet()) {
+             schemaFile.modify(event.getValue().toFile(), event.getKey());
         }
-
     }
 }

--- a/src/main/java/com/ericsson/eiffel/remrem/semantics/schemas/EiffelConstants.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/semantics/schemas/EiffelConstants.java
@@ -14,6 +14,9 @@
 */
 package com.ericsson.eiffel.remrem.semantics.schemas;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 /**
  * This is a constants class used in other classes
  * 
@@ -41,13 +44,13 @@ public final class EiffelConstants {
     public static String COM_ERICSSON_EIFFEL_SEMANTICS_EVENTS = "com.ericsson.eiffel.semantics.events.";
     public static String TYPE = "type";
     public static String OBJECTTYPE = "object";
-    public static String INPUT_EIFFEL_SCHEMAS = "src\\main\\resources\\schemas\\input";
+    public static Path INPUT_EIFFEL_SCHEMAS = Paths.get("src", "main", "resources", "schemas", "input");
     public static String EIFFEL = "eiffel";
     public static String OPERATIONS_REPO_NAME = "eiffel-operations-extension";
-    public static String USER_DIR = System.getProperty("user.dir");
-    public static String SCHEMA_LOCATION = "\\schemas";
+    public static Path USER_DIR = Paths.get(System.getProperty("user.dir"));
+    public static Path SCHEMA_LOCATION = Paths.get("schemas");
     public static String JSON_MIME_TYPE = ".json";
-    public static String USER_HOME = "user.home";
+    public static Path USER_HOME = Paths.get(System.getProperty("user.home"));
     public static String ACTIVITY = "activity";
     public static String ARTIFACT = "artifact";
     public static String SERVICE = "service";

--- a/src/main/java/com/ericsson/eiffel/remrem/semantics/schemas/SchemaFile.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/semantics/schemas/SchemaFile.java
@@ -17,6 +17,7 @@ package com.ericsson.eiffel.remrem.semantics.schemas;
 import java.io.File;
 import java.io.FileWriter;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.Map.Entry;
@@ -236,16 +237,15 @@ public class SchemaFile {
      *            an input parameter to this method
      */
     public void createNewInputJsonSchema(String jsonFileName, JsonObject jsonObject) {
-        String currentWorkingDir = EiffelConstants.USER_DIR;
         FileWriter writer = null;
-        String copyFilePath = currentWorkingDir + File.separator + EiffelConstants.INPUT_EIFFEL_SCHEMAS;
-        String newFileName = copyFilePath + File.separator + jsonFileName + EiffelConstants.JSON_MIME_TYPE;
+        Path newFileName = EiffelConstants.USER_DIR.resolve(EiffelConstants.INPUT_EIFFEL_SCHEMAS)
+                .resolve(jsonFileName + EiffelConstants.JSON_MIME_TYPE);
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         JsonParser jp = new JsonParser();
         JsonElement je = jp.parse(jsonObject.toString());
         String prettyJsonString = gson.toJson(je);
         try {
-            writer = new FileWriter(newFileName);
+            writer = new FileWriter(newFileName.toFile());
             writer.write(prettyJsonString);
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
### Applicable Issues
Closes #131 

### Description of the Change
Fixes two fatal problems encountered while trying to update schemas and generate POJOs on Linux:

* Removes backslashes from pathnames.  Reworks various constants in EiffelConstants to be java.nio.file.Path    objects instead of strings. That makes the intention of the constants    clear and we can easily work with Path objects to generate correct    paths on any platform.
* Makes schema generation independent of order of files returned from OS.    Previously all versions of the events were returned and they were all    converted and written to the same destination file. This happened to    work fine when the list of files returned from File.listFiles()    was in the correct order so that the latest version was the last file    to be processed. If that wasn't the case one or more schema files    didn't get the most recent version of the event.    We address this by using a version string parser to sort the filenames    in version order before picking the greatest version and generating a    schema from that file only.

### Alternate Designs
None.

### Benefits
Non-Windows users can update the schemas.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
