### PR TITLE
Undo manual edits made to autogenerated files

### DIFF
--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityCanceledEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityCanceledEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelActivityCanceledEvent extends Event {
+public class EiffelActivityCanceledEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityCanceledEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityCanceledEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelActivityCanceledEventMeta implements Meta {
+public class EiffelActivityCanceledEventMeta implements Meta
+{
 
     /**
      * 
@@ -46,8 +47,7 @@ public class EiffelActivityCanceledEventMeta implements Meta {
      */
     @SerializedName("version")
     @Expose
-    private EiffelActivityCanceledEventMeta.Version version = EiffelActivityCanceledEventMeta.Version
-            .fromValue("3.0.0");
+    private EiffelActivityCanceledEventMeta.Version version = EiffelActivityCanceledEventMeta.Version.fromValue("3.0.0");
     /**
      * 
      * (Required)
@@ -170,7 +170,7 @@ public class EiffelActivityCanceledEventMeta implements Meta {
         private final static Map<String, EiffelActivityCanceledEventMeta.Type> CONSTANTS = new HashMap<String, EiffelActivityCanceledEventMeta.Type>();
 
         static {
-            for (EiffelActivityCanceledEventMeta.Type c : values()) {
+            for (EiffelActivityCanceledEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -207,7 +207,7 @@ public class EiffelActivityCanceledEventMeta implements Meta {
         private final static Map<String, EiffelActivityCanceledEventMeta.Version> CONSTANTS = new HashMap<String, EiffelActivityCanceledEventMeta.Version>();
 
         static {
-            for (EiffelActivityCanceledEventMeta.Version c : values()) {
+            for (EiffelActivityCanceledEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityFinishedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityFinishedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelActivityFinishedEvent extends Event {
+public class EiffelActivityFinishedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityFinishedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityFinishedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelActivityFinishedEventMeta implements Meta {
+public class EiffelActivityFinishedEventMeta implements Meta
+{
 
     /**
      * 
@@ -46,8 +47,7 @@ public class EiffelActivityFinishedEventMeta implements Meta {
      */
     @SerializedName("version")
     @Expose
-    private EiffelActivityFinishedEventMeta.Version version = EiffelActivityFinishedEventMeta.Version
-            .fromValue("3.0.0");
+    private EiffelActivityFinishedEventMeta.Version version = EiffelActivityFinishedEventMeta.Version.fromValue("3.0.0");
     /**
      * 
      * (Required)
@@ -170,7 +170,7 @@ public class EiffelActivityFinishedEventMeta implements Meta {
         private final static Map<String, EiffelActivityFinishedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelActivityFinishedEventMeta.Type>();
 
         static {
-            for (EiffelActivityFinishedEventMeta.Type c : values()) {
+            for (EiffelActivityFinishedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -207,7 +207,7 @@ public class EiffelActivityFinishedEventMeta implements Meta {
         private final static Map<String, EiffelActivityFinishedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelActivityFinishedEventMeta.Version>();
 
         static {
-            for (EiffelActivityFinishedEventMeta.Version c : values()) {
+            for (EiffelActivityFinishedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityFinishedEventOutcome.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityFinishedEventOutcome.java
@@ -62,17 +62,22 @@ public class EiffelActivityFinishedEventOutcome {
     public enum Conclusion {
 
         @SerializedName("SUCCESSFUL")
-        SUCCESSFUL("SUCCESSFUL"), @SerializedName("UNSUCCESSFUL")
-        UNSUCCESSFUL("UNSUCCESSFUL"), @SerializedName("FAILED")
-        FAILED("FAILED"), @SerializedName("ABORTED")
-        ABORTED("ABORTED"), @SerializedName("TIMED_OUT")
-        TIMED_OUT("TIMED_OUT"), @SerializedName("INCONCLUSIVE")
+        SUCCESSFUL("SUCCESSFUL"),
+        @SerializedName("UNSUCCESSFUL")
+        UNSUCCESSFUL("UNSUCCESSFUL"),
+        @SerializedName("FAILED")
+        FAILED("FAILED"),
+        @SerializedName("ABORTED")
+        ABORTED("ABORTED"),
+        @SerializedName("TIMED_OUT")
+        TIMED_OUT("TIMED_OUT"),
+        @SerializedName("INCONCLUSIVE")
         INCONCLUSIVE("INCONCLUSIVE");
         private final String value;
         private final static Map<String, EiffelActivityFinishedEventOutcome.Conclusion> CONSTANTS = new HashMap<String, EiffelActivityFinishedEventOutcome.Conclusion>();
 
         static {
-            for (EiffelActivityFinishedEventOutcome.Conclusion c : values()) {
+            for (EiffelActivityFinishedEventOutcome.Conclusion c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityStartedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityStartedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelActivityStartedEvent extends Event {
+public class EiffelActivityStartedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityStartedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityStartedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelActivityStartedEventMeta implements Meta {
+public class EiffelActivityStartedEventMeta implements Meta
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityTriggeredEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityTriggeredEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelActivityTriggeredEvent extends Event {
+public class EiffelActivityTriggeredEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityTriggeredEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityTriggeredEventMeta.java
@@ -21,219 +21,219 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelActivityTriggeredEventMeta implements Meta {
+public class EiffelActivityTriggeredEventMeta implements Meta
+{
 
-	/**
-	 * 
-	 * (Required)
-	 * 
-	 */
-	@SerializedName("id")
-	@Expose
-	private String id;
-	/**
-	 * 
-	 * (Required)
-	 * 
-	 */
-	@SerializedName("type")
-	@Expose
-	private EiffelActivityTriggeredEventMeta.Type type;
-	/**
-	 * 
-	 * (Required)
-	 * 
-	 */
-	@SerializedName("version")
-	@Expose
-	private EiffelActivityTriggeredEventMeta.Version version = EiffelActivityTriggeredEventMeta.Version
-			.fromValue("4.0.0");
-	/**
-	 * 
-	 * (Required)
-	 * 
-	 */
-	@SerializedName("time")
-	@Expose
-	private Long time;
-	@SerializedName("tags")
-	@Expose
-	private List<String> tags = new ArrayList<String>();
-	@SerializedName("source")
-	@Expose
-	private Source source;
-	@SerializedName("security")
-	@Expose
-	private Security security;
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @SerializedName("id")
+    @Expose
+    private String id;
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @SerializedName("type")
+    @Expose
+    private EiffelActivityTriggeredEventMeta.Type type;
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @SerializedName("version")
+    @Expose
+    private EiffelActivityTriggeredEventMeta.Version version = EiffelActivityTriggeredEventMeta.Version.fromValue("4.0.0");
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @SerializedName("time")
+    @Expose
+    private Long time;
+    @SerializedName("tags")
+    @Expose
+    private List<String> tags = new ArrayList<String>();
+    @SerializedName("source")
+    @Expose
+    private Source source;
+    @SerializedName("security")
+    @Expose
+    private Security security;
 
-	/**
-	 * 
-	 * (Required)
-	 * 
-	 */
-	public String getId() {
-		return id;
-	}
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    public String getId() {
+        return id;
+    }
 
-	/**
-	 * 
-	 * (Required)
-	 * 
-	 */
-	public void setId(String id) {
-		this.id = id;
-	}
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
 
-	/**
-	 * 
-	 * (Required)
-	 * 
-	 */
-	public EiffelActivityTriggeredEventMeta.Type getType() {
-		return type;
-	}
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    public EiffelActivityTriggeredEventMeta.Type getType() {
+        return type;
+    }
 
-	/**
-	 * 
-	 * (Required)
-	 * 
-	 */
-	public void setType(EiffelActivityTriggeredEventMeta.Type type) {
-		this.type = type;
-	}
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    public void setType(EiffelActivityTriggeredEventMeta.Type type) {
+        this.type = type;
+    }
 
-	/**
-	 * 
-	 * (Required)
-	 * 
-	 */
-	public EiffelActivityTriggeredEventMeta.Version getVersion() {
-		return version;
-	}
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    public EiffelActivityTriggeredEventMeta.Version getVersion() {
+        return version;
+    }
 
-	/**
-	 * 
-	 * (Required)
-	 * 
-	 */
-	public void setVersion(EiffelActivityTriggeredEventMeta.Version version) {
-		this.version = version;
-	}
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    public void setVersion(EiffelActivityTriggeredEventMeta.Version version) {
+        this.version = version;
+    }
 
-	/**
-	 * 
-	 * (Required)
-	 * 
-	 */
-	public Long getTime() {
-		return time;
-	}
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    public Long getTime() {
+        return time;
+    }
 
-	/**
-	 * 
-	 * (Required)
-	 * 
-	 */
-	public void setTime(Long time) {
-		this.time = time;
-	}
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    public void setTime(Long time) {
+        this.time = time;
+    }
 
-	public List<String> getTags() {
-		return tags;
-	}
+    public List<String> getTags() {
+        return tags;
+    }
 
-	public void setTags(List<String> tags) {
-		this.tags = tags;
-	}
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
 
-	public Source getSource() {
-		return source;
-	}
+    public Source getSource() {
+        return source;
+    }
 
-	public void setSource(Source source) {
-		this.source = source;
-	}
+    public void setSource(Source source) {
+        this.source = source;
+    }
 
-	public Security getSecurity() {
-		return security;
-	}
+    public Security getSecurity() {
+        return security;
+    }
 
-	public void setSecurity(Security security) {
-		this.security = security;
-	}
+    public void setSecurity(Security security) {
+        this.security = security;
+    }
 
-	public enum Type {
+    public enum Type {
 
-		@SerializedName("EiffelActivityTriggeredEvent")
-		EIFFEL_ACTIVITY_TRIGGERED_EVENT("EiffelActivityTriggeredEvent");
-		private final String value;
-		private final static Map<String, EiffelActivityTriggeredEventMeta.Type> CONSTANTS = new HashMap<String, EiffelActivityTriggeredEventMeta.Type>();
+        @SerializedName("EiffelActivityTriggeredEvent")
+        EIFFEL_ACTIVITY_TRIGGERED_EVENT("EiffelActivityTriggeredEvent");
+        private final String value;
+        private final static Map<String, EiffelActivityTriggeredEventMeta.Type> CONSTANTS = new HashMap<String, EiffelActivityTriggeredEventMeta.Type>();
 
-		static {
-			for (EiffelActivityTriggeredEventMeta.Type c : values()) {
-				CONSTANTS.put(c.value, c);
-			}
-		}
+        static {
+            for (EiffelActivityTriggeredEventMeta.Type c: values()) {
+                CONSTANTS.put(c.value, c);
+            }
+        }
 
-		private Type(String value) {
-			this.value = value;
-		}
+        private Type(String value) {
+            this.value = value;
+        }
 
-		@Override
-		public String toString() {
-			return this.value;
-		}
+        @Override
+        public String toString() {
+            return this.value;
+        }
 
-		public String value() {
-			return this.value;
-		}
+        public String value() {
+            return this.value;
+        }
 
-		public static EiffelActivityTriggeredEventMeta.Type fromValue(String value) {
-			EiffelActivityTriggeredEventMeta.Type constant = CONSTANTS.get(value);
-			if (constant == null) {
-				throw new IllegalArgumentException(value);
-			} else {
-				return constant;
-			}
-		}
+        public static EiffelActivityTriggeredEventMeta.Type fromValue(String value) {
+            EiffelActivityTriggeredEventMeta.Type constant = CONSTANTS.get(value);
+            if (constant == null) {
+                throw new IllegalArgumentException(value);
+            } else {
+                return constant;
+            }
+        }
 
-	}
+    }
 
-	public enum Version {
+    public enum Version {
 
-		@SerializedName("4.0.0")
-		_4_0_0("4.0.0");
-		private final String value;
-		private final static Map<String, EiffelActivityTriggeredEventMeta.Version> CONSTANTS = new HashMap<String, EiffelActivityTriggeredEventMeta.Version>();
+        @SerializedName("4.0.0")
+        _4_0_0("4.0.0");
+        private final String value;
+        private final static Map<String, EiffelActivityTriggeredEventMeta.Version> CONSTANTS = new HashMap<String, EiffelActivityTriggeredEventMeta.Version>();
 
-		static {
-			for (EiffelActivityTriggeredEventMeta.Version c : values()) {
-				CONSTANTS.put(c.value, c);
-			}
-		}
+        static {
+            for (EiffelActivityTriggeredEventMeta.Version c: values()) {
+                CONSTANTS.put(c.value, c);
+            }
+        }
 
-		private Version(String value) {
-			this.value = value;
-		}
+        private Version(String value) {
+            this.value = value;
+        }
 
-		@Override
-		public String toString() {
-			return this.value;
-		}
+        @Override
+        public String toString() {
+            return this.value;
+        }
 
-		public String value() {
-			return this.value;
-		}
+        public String value() {
+            return this.value;
+        }
 
-		public static EiffelActivityTriggeredEventMeta.Version fromValue(String value) {
-			EiffelActivityTriggeredEventMeta.Version constant = CONSTANTS.get(value);
-			if (constant == null) {
-				throw new IllegalArgumentException(value);
-			} else {
-				return constant;
-			}
-		}
+        public static EiffelActivityTriggeredEventMeta.Version fromValue(String value) {
+            EiffelActivityTriggeredEventMeta.Version constant = CONSTANTS.get(value);
+            if (constant == null) {
+                throw new IllegalArgumentException(value);
+            } else {
+                return constant;
+            }
+        }
 
-	}
+    }
 
 }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertAcknowledgedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertAcknowledgedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelAlertAcknowledgedEvent extends Event {
+public class EiffelAlertAcknowledgedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertAcknowledgedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertAcknowledgedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelAlertAcknowledgedEventMeta implements Meta {
+public class EiffelAlertAcknowledgedEventMeta implements Meta
+{
 
     /**
      * 
@@ -46,8 +47,7 @@ public class EiffelAlertAcknowledgedEventMeta implements Meta {
      */
     @SerializedName("version")
     @Expose
-    private EiffelAlertAcknowledgedEventMeta.Version version = EiffelAlertAcknowledgedEventMeta.Version
-            .fromValue("2.0.0");
+    private EiffelAlertAcknowledgedEventMeta.Version version = EiffelAlertAcknowledgedEventMeta.Version.fromValue("2.0.0");
     /**
      * 
      * (Required)
@@ -185,7 +185,7 @@ public class EiffelAlertAcknowledgedEventMeta implements Meta {
         private final static Map<String, EiffelAlertAcknowledgedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelAlertAcknowledgedEventMeta.Type>();
 
         static {
-            for (EiffelAlertAcknowledgedEventMeta.Type c : values()) {
+            for (EiffelAlertAcknowledgedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -222,7 +222,7 @@ public class EiffelAlertAcknowledgedEventMeta implements Meta {
         private final static Map<String, EiffelAlertAcknowledgedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelAlertAcknowledgedEventMeta.Version>();
 
         static {
-            for (EiffelAlertAcknowledgedEventMeta.Version c : values()) {
+            for (EiffelAlertAcknowledgedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertCeasedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertCeasedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelAlertCeasedEvent extends Event {
+public class EiffelAlertCeasedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertCeasedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertCeasedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelAlertCeasedEventMeta implements Meta {
+public class EiffelAlertCeasedEventMeta implements Meta
+{
 
     /**
      * 
@@ -184,7 +185,7 @@ public class EiffelAlertCeasedEventMeta implements Meta {
         private final static Map<String, EiffelAlertCeasedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelAlertCeasedEventMeta.Type>();
 
         static {
-            for (EiffelAlertCeasedEventMeta.Type c : values()) {
+            for (EiffelAlertCeasedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -221,7 +222,7 @@ public class EiffelAlertCeasedEventMeta implements Meta {
         private final static Map<String, EiffelAlertCeasedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelAlertCeasedEventMeta.Version>();
 
         static {
-            for (EiffelAlertCeasedEventMeta.Version c : values()) {
+            for (EiffelAlertCeasedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertRaisedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertRaisedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelAlertRaisedEvent extends Event {
+public class EiffelAlertRaisedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertRaisedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertRaisedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelAlertRaisedEventMeta implements Meta {
+public class EiffelAlertRaisedEventMeta implements Meta
+{
 
     /**
      * 
@@ -184,7 +185,7 @@ public class EiffelAlertRaisedEventMeta implements Meta {
         private final static Map<String, EiffelAlertRaisedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelAlertRaisedEventMeta.Type>();
 
         static {
-            for (EiffelAlertRaisedEventMeta.Type c : values()) {
+            for (EiffelAlertRaisedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -221,7 +222,7 @@ public class EiffelAlertRaisedEventMeta implements Meta {
         private final static Map<String, EiffelAlertRaisedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelAlertRaisedEventMeta.Version>();
 
         static {
-            for (EiffelAlertRaisedEventMeta.Version c : values()) {
+            for (EiffelAlertRaisedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAnnouncementPublishedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAnnouncementPublishedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelAnnouncementPublishedEvent extends Event {
+public class EiffelAnnouncementPublishedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAnnouncementPublishedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAnnouncementPublishedEventData.java
@@ -127,17 +127,22 @@ public class EiffelAnnouncementPublishedEventData {
     public enum Severity {
 
         @SerializedName("MINOR")
-        MINOR("MINOR"), @SerializedName("MAJOR")
-        MAJOR("MAJOR"), @SerializedName("CRITICAL")
-        CRITICAL("CRITICAL"), @SerializedName("BLOCKER")
-        BLOCKER("BLOCKER"), @SerializedName("CLOSED")
-        CLOSED("CLOSED"), @SerializedName("CANCELED")
+        MINOR("MINOR"),
+        @SerializedName("MAJOR")
+        MAJOR("MAJOR"),
+        @SerializedName("CRITICAL")
+        CRITICAL("CRITICAL"),
+        @SerializedName("BLOCKER")
+        BLOCKER("BLOCKER"),
+        @SerializedName("CLOSED")
+        CLOSED("CLOSED"),
+        @SerializedName("CANCELED")
         CANCELED("CANCELED");
         private final String value;
         private final static Map<String, EiffelAnnouncementPublishedEventData.Severity> CONSTANTS = new HashMap<String, EiffelAnnouncementPublishedEventData.Severity>();
 
         static {
-            for (EiffelAnnouncementPublishedEventData.Severity c : values()) {
+            for (EiffelAnnouncementPublishedEventData.Severity c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAnnouncementPublishedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAnnouncementPublishedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelAnnouncementPublishedEventMeta implements Meta {
+public class EiffelAnnouncementPublishedEventMeta implements Meta
+{
 
     /**
      * 
@@ -46,8 +47,7 @@ public class EiffelAnnouncementPublishedEventMeta implements Meta {
      */
     @SerializedName("version")
     @Expose
-    private EiffelAnnouncementPublishedEventMeta.Version version = EiffelAnnouncementPublishedEventMeta.Version
-            .fromValue("3.0.0");
+    private EiffelAnnouncementPublishedEventMeta.Version version = EiffelAnnouncementPublishedEventMeta.Version.fromValue("3.0.0");
     /**
      * 
      * (Required)
@@ -170,7 +170,7 @@ public class EiffelAnnouncementPublishedEventMeta implements Meta {
         private final static Map<String, EiffelAnnouncementPublishedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelAnnouncementPublishedEventMeta.Type>();
 
         static {
-            for (EiffelAnnouncementPublishedEventMeta.Type c : values()) {
+            for (EiffelAnnouncementPublishedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -207,7 +207,7 @@ public class EiffelAnnouncementPublishedEventMeta implements Meta {
         private final static Map<String, EiffelAnnouncementPublishedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelAnnouncementPublishedEventMeta.Version>();
 
         static {
-            for (EiffelAnnouncementPublishedEventMeta.Version c : values()) {
+            for (EiffelAnnouncementPublishedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactCreatedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactCreatedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelArtifactCreatedEvent extends Event {
+public class EiffelArtifactCreatedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactCreatedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactCreatedEventData.java
@@ -91,8 +91,7 @@ public class EiffelArtifactCreatedEventData {
         return requiresImplementation;
     }
 
-    public void setRequiresImplementation(
-            EiffelArtifactCreatedEventData.RequiresImplementation requiresImplementation) {
+    public void setRequiresImplementation(EiffelArtifactCreatedEventData.RequiresImplementation requiresImplementation) {
         this.requiresImplementation = requiresImplementation;
     }
 
@@ -131,15 +130,18 @@ public class EiffelArtifactCreatedEventData {
     public enum RequiresImplementation {
 
         @SerializedName("NONE")
-        NONE("NONE"), @SerializedName("ANY")
-        ANY("ANY"), @SerializedName("EXACTLY_ONE")
-        EXACTLY_ONE("EXACTLY_ONE"), @SerializedName("AT_LEAST_ONE")
+        NONE("NONE"),
+        @SerializedName("ANY")
+        ANY("ANY"),
+        @SerializedName("EXACTLY_ONE")
+        EXACTLY_ONE("EXACTLY_ONE"),
+        @SerializedName("AT_LEAST_ONE")
         AT_LEAST_ONE("AT_LEAST_ONE");
         private final String value;
         private final static Map<String, EiffelArtifactCreatedEventData.RequiresImplementation> CONSTANTS = new HashMap<String, EiffelArtifactCreatedEventData.RequiresImplementation>();
 
         static {
-            for (EiffelArtifactCreatedEventData.RequiresImplementation c : values()) {
+            for (EiffelArtifactCreatedEventData.RequiresImplementation c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactCreatedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactCreatedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelArtifactCreatedEventMeta implements Meta {
+public class EiffelArtifactCreatedEventMeta implements Meta
+{
 
     /**
      * 
@@ -169,7 +170,7 @@ public class EiffelArtifactCreatedEventMeta implements Meta {
         private final static Map<String, EiffelArtifactCreatedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelArtifactCreatedEventMeta.Type>();
 
         static {
-            for (EiffelArtifactCreatedEventMeta.Type c : values()) {
+            for (EiffelArtifactCreatedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -206,7 +207,7 @@ public class EiffelArtifactCreatedEventMeta implements Meta {
         private final static Map<String, EiffelArtifactCreatedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelArtifactCreatedEventMeta.Version>();
 
         static {
-            for (EiffelArtifactCreatedEventMeta.Version c : values()) {
+            for (EiffelArtifactCreatedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactDeployedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactDeployedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelArtifactDeployedEvent extends Event {
+public class EiffelArtifactDeployedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactDeployedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactDeployedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelArtifactDeployedEventMeta implements Meta {
+public class EiffelArtifactDeployedEventMeta implements Meta
+{
 
     /**
      * 
@@ -46,8 +47,7 @@ public class EiffelArtifactDeployedEventMeta implements Meta {
      */
     @SerializedName("version")
     @Expose
-    private EiffelArtifactDeployedEventMeta.Version version = EiffelArtifactDeployedEventMeta.Version
-            .fromValue("2.0.0");
+    private EiffelArtifactDeployedEventMeta.Version version = EiffelArtifactDeployedEventMeta.Version.fromValue("2.0.0");
     /**
      * 
      * (Required)
@@ -185,7 +185,7 @@ public class EiffelArtifactDeployedEventMeta implements Meta {
         private final static Map<String, EiffelArtifactDeployedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelArtifactDeployedEventMeta.Type>();
 
         static {
-            for (EiffelArtifactDeployedEventMeta.Type c : values()) {
+            for (EiffelArtifactDeployedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -222,7 +222,7 @@ public class EiffelArtifactDeployedEventMeta implements Meta {
         private final static Map<String, EiffelArtifactDeployedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelArtifactDeployedEventMeta.Version>();
 
         static {
-            for (EiffelArtifactDeployedEventMeta.Version c : values()) {
+            for (EiffelArtifactDeployedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactPublishedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactPublishedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelArtifactPublishedEvent extends Event {
+public class EiffelArtifactPublishedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactPublishedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactPublishedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelArtifactPublishedEventMeta implements Meta {
+public class EiffelArtifactPublishedEventMeta implements Meta
+{
 
     /**
      * 
@@ -46,8 +47,7 @@ public class EiffelArtifactPublishedEventMeta implements Meta {
      */
     @SerializedName("version")
     @Expose
-    private EiffelArtifactPublishedEventMeta.Version version = EiffelArtifactPublishedEventMeta.Version
-            .fromValue("3.0.0");
+    private EiffelArtifactPublishedEventMeta.Version version = EiffelArtifactPublishedEventMeta.Version.fromValue("3.0.0");
     /**
      * 
      * (Required)
@@ -170,7 +170,7 @@ public class EiffelArtifactPublishedEventMeta implements Meta {
         private final static Map<String, EiffelArtifactPublishedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelArtifactPublishedEventMeta.Type>();
 
         static {
-            for (EiffelArtifactPublishedEventMeta.Type c : values()) {
+            for (EiffelArtifactPublishedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -207,7 +207,7 @@ public class EiffelArtifactPublishedEventMeta implements Meta {
         private final static Map<String, EiffelArtifactPublishedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelArtifactPublishedEventMeta.Version>();
 
         static {
-            for (EiffelArtifactPublishedEventMeta.Version c : values()) {
+            for (EiffelArtifactPublishedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactReusedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactReusedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelArtifactReusedEvent extends Event {
+public class EiffelArtifactReusedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactReusedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactReusedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelArtifactReusedEventMeta implements Meta {
+public class EiffelArtifactReusedEventMeta implements Meta
+{
 
     /**
      * 
@@ -169,7 +170,7 @@ public class EiffelArtifactReusedEventMeta implements Meta {
         private final static Map<String, EiffelArtifactReusedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelArtifactReusedEventMeta.Type>();
 
         static {
-            for (EiffelArtifactReusedEventMeta.Type c : values()) {
+            for (EiffelArtifactReusedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -206,7 +207,7 @@ public class EiffelArtifactReusedEventMeta implements Meta {
         private final static Map<String, EiffelArtifactReusedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelArtifactReusedEventMeta.Version>();
 
         static {
-            for (EiffelArtifactReusedEventMeta.Version c : values()) {
+            for (EiffelArtifactReusedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelCompositionDefinedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelCompositionDefinedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelCompositionDefinedEvent extends Event {
+public class EiffelCompositionDefinedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelCompositionDefinedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelCompositionDefinedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelCompositionDefinedEventMeta implements Meta {
+public class EiffelCompositionDefinedEventMeta implements Meta
+{
 
     /**
      * 
@@ -46,8 +47,7 @@ public class EiffelCompositionDefinedEventMeta implements Meta {
      */
     @SerializedName("version")
     @Expose
-    private EiffelCompositionDefinedEventMeta.Version version = EiffelCompositionDefinedEventMeta.Version
-            .fromValue("3.0.0");
+    private EiffelCompositionDefinedEventMeta.Version version = EiffelCompositionDefinedEventMeta.Version.fromValue("3.0.0");
     /**
      * 
      * (Required)
@@ -170,7 +170,7 @@ public class EiffelCompositionDefinedEventMeta implements Meta {
         private final static Map<String, EiffelCompositionDefinedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelCompositionDefinedEventMeta.Type>();
 
         static {
-            for (EiffelCompositionDefinedEventMeta.Type c : values()) {
+            for (EiffelCompositionDefinedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -207,7 +207,7 @@ public class EiffelCompositionDefinedEventMeta implements Meta {
         private final static Map<String, EiffelCompositionDefinedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelCompositionDefinedEventMeta.Version>();
 
         static {
-            for (EiffelCompositionDefinedEventMeta.Version c : values()) {
+            for (EiffelCompositionDefinedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelConfidenceLevelModifiedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelConfidenceLevelModifiedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelConfidenceLevelModifiedEvent extends Event {
+public class EiffelConfidenceLevelModifiedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelConfidenceLevelModifiedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelConfidenceLevelModifiedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelConfidenceLevelModifiedEventMeta implements Meta {
+public class EiffelConfidenceLevelModifiedEventMeta implements Meta
+{
 
     /**
      * 
@@ -46,8 +47,7 @@ public class EiffelConfidenceLevelModifiedEventMeta implements Meta {
      */
     @SerializedName("version")
     @Expose
-    private EiffelConfidenceLevelModifiedEventMeta.Version version = EiffelConfidenceLevelModifiedEventMeta.Version
-            .fromValue("3.0.0");
+    private EiffelConfidenceLevelModifiedEventMeta.Version version = EiffelConfidenceLevelModifiedEventMeta.Version.fromValue("3.0.0");
     /**
      * 
      * (Required)
@@ -170,7 +170,7 @@ public class EiffelConfidenceLevelModifiedEventMeta implements Meta {
         private final static Map<String, EiffelConfidenceLevelModifiedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelConfidenceLevelModifiedEventMeta.Type>();
 
         static {
-            for (EiffelConfidenceLevelModifiedEventMeta.Type c : values()) {
+            for (EiffelConfidenceLevelModifiedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -207,7 +207,7 @@ public class EiffelConfidenceLevelModifiedEventMeta implements Meta {
         private final static Map<String, EiffelConfidenceLevelModifiedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelConfidenceLevelModifiedEventMeta.Version>();
 
         static {
-            for (EiffelConfidenceLevelModifiedEventMeta.Version c : values()) {
+            for (EiffelConfidenceLevelModifiedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelEnvironmentDefinedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelEnvironmentDefinedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelEnvironmentDefinedEvent extends Event {
+public class EiffelEnvironmentDefinedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelEnvironmentDefinedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelEnvironmentDefinedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelEnvironmentDefinedEventMeta implements Meta {
+public class EiffelEnvironmentDefinedEventMeta implements Meta
+{
 
     /**
      * 
@@ -46,8 +47,7 @@ public class EiffelEnvironmentDefinedEventMeta implements Meta {
      */
     @SerializedName("version")
     @Expose
-    private EiffelEnvironmentDefinedEventMeta.Version version = EiffelEnvironmentDefinedEventMeta.Version
-            .fromValue("3.0.0");
+    private EiffelEnvironmentDefinedEventMeta.Version version = EiffelEnvironmentDefinedEventMeta.Version.fromValue("3.0.0");
     /**
      * 
      * (Required)
@@ -170,7 +170,7 @@ public class EiffelEnvironmentDefinedEventMeta implements Meta {
         private final static Map<String, EiffelEnvironmentDefinedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelEnvironmentDefinedEventMeta.Type>();
 
         static {
-            for (EiffelEnvironmentDefinedEventMeta.Type c : values()) {
+            for (EiffelEnvironmentDefinedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -207,7 +207,7 @@ public class EiffelEnvironmentDefinedEventMeta implements Meta {
         private final static Map<String, EiffelEnvironmentDefinedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelEnvironmentDefinedEventMeta.Version>();
 
         static {
-            for (EiffelEnvironmentDefinedEventMeta.Version c : values()) {
+            for (EiffelEnvironmentDefinedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelFlowContextDefinedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelFlowContextDefinedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelFlowContextDefinedEvent extends Event {
+public class EiffelFlowContextDefinedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelFlowContextDefinedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelFlowContextDefinedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelFlowContextDefinedEventMeta implements Meta {
+public class EiffelFlowContextDefinedEventMeta implements Meta
+{
 
     /**
      * 
@@ -46,8 +47,7 @@ public class EiffelFlowContextDefinedEventMeta implements Meta {
      */
     @SerializedName("version")
     @Expose
-    private EiffelFlowContextDefinedEventMeta.Version version = EiffelFlowContextDefinedEventMeta.Version
-            .fromValue("3.0.0");
+    private EiffelFlowContextDefinedEventMeta.Version version = EiffelFlowContextDefinedEventMeta.Version.fromValue("3.0.0");
     /**
      * 
      * (Required)
@@ -170,7 +170,7 @@ public class EiffelFlowContextDefinedEventMeta implements Meta {
         private final static Map<String, EiffelFlowContextDefinedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelFlowContextDefinedEventMeta.Type>();
 
         static {
-            for (EiffelFlowContextDefinedEventMeta.Type c : values()) {
+            for (EiffelFlowContextDefinedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -207,7 +207,7 @@ public class EiffelFlowContextDefinedEventMeta implements Meta {
         private final static Map<String, EiffelFlowContextDefinedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelFlowContextDefinedEventMeta.Version>();
 
         static {
-            for (EiffelFlowContextDefinedEventMeta.Version c : values()) {
+            for (EiffelFlowContextDefinedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelIssueDefinedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelIssueDefinedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelIssueDefinedEvent extends Event {
+public class EiffelIssueDefinedEvent
+    extends Event
+{
 
     @SerializedName("meta")
     @Expose

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelIssueDefinedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelIssueDefinedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelIssueDefinedEventMeta implements Meta {
+public class EiffelIssueDefinedEventMeta implements Meta
+{
 
     /**
      * 
@@ -169,7 +170,7 @@ public class EiffelIssueDefinedEventMeta implements Meta {
         private final static Map<String, EiffelIssueDefinedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelIssueDefinedEventMeta.Type>();
 
         static {
-            for (EiffelIssueDefinedEventMeta.Type c : values()) {
+            for (EiffelIssueDefinedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -206,7 +207,7 @@ public class EiffelIssueDefinedEventMeta implements Meta {
         private final static Map<String, EiffelIssueDefinedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelIssueDefinedEventMeta.Version>();
 
         static {
-            for (EiffelIssueDefinedEventMeta.Version c : values()) {
+            for (EiffelIssueDefinedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelIssueVerifiedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelIssueVerifiedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelIssueVerifiedEvent extends Event {
+public class EiffelIssueVerifiedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelIssueVerifiedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelIssueVerifiedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelIssueVerifiedEventMeta implements Meta {
+public class EiffelIssueVerifiedEventMeta implements Meta
+{
 
     /**
      * 
@@ -169,7 +170,7 @@ public class EiffelIssueVerifiedEventMeta implements Meta {
         private final static Map<String, EiffelIssueVerifiedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelIssueVerifiedEventMeta.Type>();
 
         static {
-            for (EiffelIssueVerifiedEventMeta.Type c : values()) {
+            for (EiffelIssueVerifiedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -206,7 +207,7 @@ public class EiffelIssueVerifiedEventMeta implements Meta {
         private final static Map<String, EiffelIssueVerifiedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelIssueVerifiedEventMeta.Version>();
 
         static {
-            for (EiffelIssueVerifiedEventMeta.Version c : values()) {
+            for (EiffelIssueVerifiedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceAllocatedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceAllocatedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelServiceAllocatedEvent extends Event {
+public class EiffelServiceAllocatedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceAllocatedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceAllocatedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelServiceAllocatedEventMeta implements Meta {
+public class EiffelServiceAllocatedEventMeta implements Meta
+{
 
     /**
      * 
@@ -46,8 +47,7 @@ public class EiffelServiceAllocatedEventMeta implements Meta {
      */
     @SerializedName("version")
     @Expose
-    private EiffelServiceAllocatedEventMeta.Version version = EiffelServiceAllocatedEventMeta.Version
-            .fromValue("2.0.0");
+    private EiffelServiceAllocatedEventMeta.Version version = EiffelServiceAllocatedEventMeta.Version.fromValue("2.0.0");
     /**
      * 
      * (Required)
@@ -185,7 +185,7 @@ public class EiffelServiceAllocatedEventMeta implements Meta {
         private final static Map<String, EiffelServiceAllocatedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelServiceAllocatedEventMeta.Type>();
 
         static {
-            for (EiffelServiceAllocatedEventMeta.Type c : values()) {
+            for (EiffelServiceAllocatedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -222,7 +222,7 @@ public class EiffelServiceAllocatedEventMeta implements Meta {
         private final static Map<String, EiffelServiceAllocatedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelServiceAllocatedEventMeta.Version>();
 
         static {
-            for (EiffelServiceAllocatedEventMeta.Version c : values()) {
+            for (EiffelServiceAllocatedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceDeployedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceDeployedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelServiceDeployedEventMeta implements Meta {
+public class EiffelServiceDeployedEventMeta implements Meta
+{
 
     /**
      * 
@@ -184,7 +185,7 @@ public class EiffelServiceDeployedEventMeta implements Meta {
         private final static Map<String, EiffelServiceDeployedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelServiceDeployedEventMeta.Type>();
 
         static {
-            for (EiffelServiceDeployedEventMeta.Type c : values()) {
+            for (EiffelServiceDeployedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -221,7 +222,7 @@ public class EiffelServiceDeployedEventMeta implements Meta {
         private final static Map<String, EiffelServiceDeployedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelServiceDeployedEventMeta.Version>();
 
         static {
-            for (EiffelServiceDeployedEventMeta.Version c : values()) {
+            for (EiffelServiceDeployedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceDiscontinuedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceDiscontinuedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelServiceDiscontinuedEvent extends Event {
+public class EiffelServiceDiscontinuedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceDiscontinuedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceDiscontinuedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelServiceDiscontinuedEventMeta implements Meta {
+public class EiffelServiceDiscontinuedEventMeta implements Meta
+{
 
     /**
      * 
@@ -46,8 +47,7 @@ public class EiffelServiceDiscontinuedEventMeta implements Meta {
      */
     @SerializedName("version")
     @Expose
-    private EiffelServiceDiscontinuedEventMeta.Version version = EiffelServiceDiscontinuedEventMeta.Version
-            .fromValue("2.0.0");
+    private EiffelServiceDiscontinuedEventMeta.Version version = EiffelServiceDiscontinuedEventMeta.Version.fromValue("2.0.0");
     /**
      * 
      * (Required)
@@ -185,7 +185,7 @@ public class EiffelServiceDiscontinuedEventMeta implements Meta {
         private final static Map<String, EiffelServiceDiscontinuedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelServiceDiscontinuedEventMeta.Type>();
 
         static {
-            for (EiffelServiceDiscontinuedEventMeta.Type c : values()) {
+            for (EiffelServiceDiscontinuedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -222,7 +222,7 @@ public class EiffelServiceDiscontinuedEventMeta implements Meta {
         private final static Map<String, EiffelServiceDiscontinuedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelServiceDiscontinuedEventMeta.Version>();
 
         static {
-            for (EiffelServiceDiscontinuedEventMeta.Version c : values()) {
+            for (EiffelServiceDiscontinuedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceReturnedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceReturnedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelServiceReturnedEvent extends Event {
+public class EiffelServiceReturnedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceReturnedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceReturnedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelServiceReturnedEventMeta implements Meta {
+public class EiffelServiceReturnedEventMeta implements Meta
+{
 
     /**
      * 
@@ -184,7 +185,7 @@ public class EiffelServiceReturnedEventMeta implements Meta {
         private final static Map<String, EiffelServiceReturnedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelServiceReturnedEventMeta.Type>();
 
         static {
-            for (EiffelServiceReturnedEventMeta.Type c : values()) {
+            for (EiffelServiceReturnedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -221,7 +222,7 @@ public class EiffelServiceReturnedEventMeta implements Meta {
         private final static Map<String, EiffelServiceReturnedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelServiceReturnedEventMeta.Version>();
 
         static {
-            for (EiffelServiceReturnedEventMeta.Version c : values()) {
+            for (EiffelServiceReturnedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceStartedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceStartedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelServiceStartedEvent extends Event {
+public class EiffelServiceStartedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceStartedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceStartedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelServiceStartedEventMeta implements Meta {
+public class EiffelServiceStartedEventMeta implements Meta
+{
 
     /**
      * 
@@ -184,7 +185,7 @@ public class EiffelServiceStartedEventMeta implements Meta {
         private final static Map<String, EiffelServiceStartedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelServiceStartedEventMeta.Type>();
 
         static {
-            for (EiffelServiceStartedEventMeta.Type c : values()) {
+            for (EiffelServiceStartedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -221,7 +222,7 @@ public class EiffelServiceStartedEventMeta implements Meta {
         private final static Map<String, EiffelServiceStartedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelServiceStartedEventMeta.Version>();
 
         static {
-            for (EiffelServiceStartedEventMeta.Version c : values()) {
+            for (EiffelServiceStartedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceStoppedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceStoppedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelServiceStoppedEvent extends Event {
+public class EiffelServiceStoppedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceStoppedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceStoppedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelServiceStoppedEventMeta implements Meta {
+public class EiffelServiceStoppedEventMeta implements Meta
+{
 
     /**
      * 
@@ -184,7 +185,7 @@ public class EiffelServiceStoppedEventMeta implements Meta {
         private final static Map<String, EiffelServiceStoppedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelServiceStoppedEventMeta.Type>();
 
         static {
-            for (EiffelServiceStoppedEventMeta.Type c : values()) {
+            for (EiffelServiceStoppedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -221,7 +222,7 @@ public class EiffelServiceStoppedEventMeta implements Meta {
         private final static Map<String, EiffelServiceStoppedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelServiceStoppedEventMeta.Version>();
 
         static {
-            for (EiffelServiceStoppedEventMeta.Version c : values()) {
+            for (EiffelServiceStoppedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelSourceChangeCreatedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelSourceChangeCreatedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelSourceChangeCreatedEvent extends Event {
+public class EiffelSourceChangeCreatedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelSourceChangeCreatedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelSourceChangeCreatedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelSourceChangeCreatedEventMeta implements Meta {
+public class EiffelSourceChangeCreatedEventMeta implements Meta
+{
 
     /**
      * 
@@ -46,8 +47,7 @@ public class EiffelSourceChangeCreatedEventMeta implements Meta {
      */
     @SerializedName("version")
     @Expose
-    private EiffelSourceChangeCreatedEventMeta.Version version = EiffelSourceChangeCreatedEventMeta.Version
-            .fromValue("4.0.0");
+    private EiffelSourceChangeCreatedEventMeta.Version version = EiffelSourceChangeCreatedEventMeta.Version.fromValue("4.0.0");
     /**
      * 
      * (Required)
@@ -170,7 +170,7 @@ public class EiffelSourceChangeCreatedEventMeta implements Meta {
         private final static Map<String, EiffelSourceChangeCreatedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelSourceChangeCreatedEventMeta.Type>();
 
         static {
-            for (EiffelSourceChangeCreatedEventMeta.Type c : values()) {
+            for (EiffelSourceChangeCreatedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -207,7 +207,7 @@ public class EiffelSourceChangeCreatedEventMeta implements Meta {
         private final static Map<String, EiffelSourceChangeCreatedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelSourceChangeCreatedEventMeta.Version>();
 
         static {
-            for (EiffelSourceChangeCreatedEventMeta.Version c : values()) {
+            for (EiffelSourceChangeCreatedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelSourceChangeSubmittedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelSourceChangeSubmittedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelSourceChangeSubmittedEvent extends Event {
+public class EiffelSourceChangeSubmittedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelSourceChangeSubmittedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelSourceChangeSubmittedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelSourceChangeSubmittedEventMeta implements Meta {
+public class EiffelSourceChangeSubmittedEventMeta implements Meta
+{
 
     /**
      * 
@@ -46,8 +47,7 @@ public class EiffelSourceChangeSubmittedEventMeta implements Meta {
      */
     @SerializedName("version")
     @Expose
-    private EiffelSourceChangeSubmittedEventMeta.Version version = EiffelSourceChangeSubmittedEventMeta.Version
-            .fromValue("3.0.0");
+    private EiffelSourceChangeSubmittedEventMeta.Version version = EiffelSourceChangeSubmittedEventMeta.Version.fromValue("3.0.0");
     /**
      * 
      * (Required)
@@ -170,7 +170,7 @@ public class EiffelSourceChangeSubmittedEventMeta implements Meta {
         private final static Map<String, EiffelSourceChangeSubmittedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelSourceChangeSubmittedEventMeta.Type>();
 
         static {
-            for (EiffelSourceChangeSubmittedEventMeta.Type c : values()) {
+            for (EiffelSourceChangeSubmittedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -207,7 +207,7 @@ public class EiffelSourceChangeSubmittedEventMeta implements Meta {
         private final static Map<String, EiffelSourceChangeSubmittedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelSourceChangeSubmittedEventMeta.Version>();
 
         static {
-            for (EiffelSourceChangeSubmittedEventMeta.Version c : values()) {
+            for (EiffelSourceChangeSubmittedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseCanceledEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseCanceledEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelTestCaseCanceledEvent extends Event {
+public class EiffelTestCaseCanceledEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseCanceledEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseCanceledEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelTestCaseCanceledEventMeta implements Meta {
+public class EiffelTestCaseCanceledEventMeta implements Meta
+{
 
     /**
      * 
@@ -46,8 +47,7 @@ public class EiffelTestCaseCanceledEventMeta implements Meta {
      */
     @SerializedName("version")
     @Expose
-    private EiffelTestCaseCanceledEventMeta.Version version = EiffelTestCaseCanceledEventMeta.Version
-            .fromValue("3.0.0");
+    private EiffelTestCaseCanceledEventMeta.Version version = EiffelTestCaseCanceledEventMeta.Version.fromValue("3.0.0");
     /**
      * 
      * (Required)
@@ -170,7 +170,7 @@ public class EiffelTestCaseCanceledEventMeta implements Meta {
         private final static Map<String, EiffelTestCaseCanceledEventMeta.Type> CONSTANTS = new HashMap<String, EiffelTestCaseCanceledEventMeta.Type>();
 
         static {
-            for (EiffelTestCaseCanceledEventMeta.Type c : values()) {
+            for (EiffelTestCaseCanceledEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -207,7 +207,7 @@ public class EiffelTestCaseCanceledEventMeta implements Meta {
         private final static Map<String, EiffelTestCaseCanceledEventMeta.Version> CONSTANTS = new HashMap<String, EiffelTestCaseCanceledEventMeta.Version>();
 
         static {
-            for (EiffelTestCaseCanceledEventMeta.Version c : values()) {
+            for (EiffelTestCaseCanceledEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseFinishedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseFinishedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelTestCaseFinishedEvent extends Event {
+public class EiffelTestCaseFinishedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseFinishedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseFinishedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelTestCaseFinishedEventMeta implements Meta {
+public class EiffelTestCaseFinishedEventMeta implements Meta
+{
 
     /**
      * 
@@ -46,8 +47,7 @@ public class EiffelTestCaseFinishedEventMeta implements Meta {
      */
     @SerializedName("version")
     @Expose
-    private EiffelTestCaseFinishedEventMeta.Version version = EiffelTestCaseFinishedEventMeta.Version
-            .fromValue("3.0.0");
+    private EiffelTestCaseFinishedEventMeta.Version version = EiffelTestCaseFinishedEventMeta.Version.fromValue("3.0.0");
     /**
      * 
      * (Required)
@@ -170,7 +170,7 @@ public class EiffelTestCaseFinishedEventMeta implements Meta {
         private final static Map<String, EiffelTestCaseFinishedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelTestCaseFinishedEventMeta.Type>();
 
         static {
-            for (EiffelTestCaseFinishedEventMeta.Type c : values()) {
+            for (EiffelTestCaseFinishedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -207,7 +207,7 @@ public class EiffelTestCaseFinishedEventMeta implements Meta {
         private final static Map<String, EiffelTestCaseFinishedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelTestCaseFinishedEventMeta.Version>();
 
         static {
-            for (EiffelTestCaseFinishedEventMeta.Version c : values()) {
+            for (EiffelTestCaseFinishedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseFinishedEventOutcome.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseFinishedEventOutcome.java
@@ -101,16 +101,20 @@ public class EiffelTestCaseFinishedEventOutcome {
     public enum Conclusion {
 
         @SerializedName("SUCCESSFUL")
-        SUCCESSFUL("SUCCESSFUL"), @SerializedName("FAILED")
-        FAILED("FAILED"), @SerializedName("ABORTED")
-        ABORTED("ABORTED"), @SerializedName("TIMED_OUT")
-        TIMED_OUT("TIMED_OUT"), @SerializedName("INCONCLUSIVE")
+        SUCCESSFUL("SUCCESSFUL"),
+        @SerializedName("FAILED")
+        FAILED("FAILED"),
+        @SerializedName("ABORTED")
+        ABORTED("ABORTED"),
+        @SerializedName("TIMED_OUT")
+        TIMED_OUT("TIMED_OUT"),
+        @SerializedName("INCONCLUSIVE")
         INCONCLUSIVE("INCONCLUSIVE");
         private final String value;
         private final static Map<String, EiffelTestCaseFinishedEventOutcome.Conclusion> CONSTANTS = new HashMap<String, EiffelTestCaseFinishedEventOutcome.Conclusion>();
 
         static {
-            for (EiffelTestCaseFinishedEventOutcome.Conclusion c : values()) {
+            for (EiffelTestCaseFinishedEventOutcome.Conclusion c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -142,14 +146,16 @@ public class EiffelTestCaseFinishedEventOutcome {
     public enum Verdict {
 
         @SerializedName("PASSED")
-        PASSED("PASSED"), @SerializedName("FAILED")
-        FAILED("FAILED"), @SerializedName("INCONCLUSIVE")
+        PASSED("PASSED"),
+        @SerializedName("FAILED")
+        FAILED("FAILED"),
+        @SerializedName("INCONCLUSIVE")
         INCONCLUSIVE("INCONCLUSIVE");
         private final String value;
         private final static Map<String, EiffelTestCaseFinishedEventOutcome.Verdict> CONSTANTS = new HashMap<String, EiffelTestCaseFinishedEventOutcome.Verdict>();
 
         static {
-            for (EiffelTestCaseFinishedEventOutcome.Verdict c : values()) {
+            for (EiffelTestCaseFinishedEventOutcome.Verdict c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseStartedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseStartedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelTestCaseStartedEvent extends Event {
+public class EiffelTestCaseStartedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseStartedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseStartedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelTestCaseStartedEventMeta implements Meta {
+public class EiffelTestCaseStartedEventMeta implements Meta
+{
 
     /**
      * 
@@ -169,7 +170,7 @@ public class EiffelTestCaseStartedEventMeta implements Meta {
         private final static Map<String, EiffelTestCaseStartedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelTestCaseStartedEventMeta.Type>();
 
         static {
-            for (EiffelTestCaseStartedEventMeta.Type c : values()) {
+            for (EiffelTestCaseStartedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -206,7 +207,7 @@ public class EiffelTestCaseStartedEventMeta implements Meta {
         private final static Map<String, EiffelTestCaseStartedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelTestCaseStartedEventMeta.Version>();
 
         static {
-            for (EiffelTestCaseStartedEventMeta.Version c : values()) {
+            for (EiffelTestCaseStartedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseTriggeredEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseTriggeredEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelTestCaseTriggeredEvent extends Event {
+public class EiffelTestCaseTriggeredEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseTriggeredEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseTriggeredEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelTestCaseTriggeredEventMeta implements Meta {
+public class EiffelTestCaseTriggeredEventMeta implements Meta
+{
 
     /**
      * 
@@ -46,8 +47,7 @@ public class EiffelTestCaseTriggeredEventMeta implements Meta {
      */
     @SerializedName("version")
     @Expose
-    private EiffelTestCaseTriggeredEventMeta.Version version = EiffelTestCaseTriggeredEventMeta.Version
-            .fromValue("3.0.0");
+    private EiffelTestCaseTriggeredEventMeta.Version version = EiffelTestCaseTriggeredEventMeta.Version.fromValue("3.0.0");
     /**
      * 
      * (Required)
@@ -170,7 +170,7 @@ public class EiffelTestCaseTriggeredEventMeta implements Meta {
         private final static Map<String, EiffelTestCaseTriggeredEventMeta.Type> CONSTANTS = new HashMap<String, EiffelTestCaseTriggeredEventMeta.Type>();
 
         static {
-            for (EiffelTestCaseTriggeredEventMeta.Type c : values()) {
+            for (EiffelTestCaseTriggeredEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -207,7 +207,7 @@ public class EiffelTestCaseTriggeredEventMeta implements Meta {
         private final static Map<String, EiffelTestCaseTriggeredEventMeta.Version> CONSTANTS = new HashMap<String, EiffelTestCaseTriggeredEventMeta.Version>();
 
         static {
-            for (EiffelTestCaseTriggeredEventMeta.Version c : values()) {
+            for (EiffelTestCaseTriggeredEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestExecutionRecipeCollectionCreatedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestExecutionRecipeCollectionCreatedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelTestExecutionRecipeCollectionCreatedEvent extends Event {
+public class EiffelTestExecutionRecipeCollectionCreatedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestExecutionRecipeCollectionCreatedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestExecutionRecipeCollectionCreatedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelTestExecutionRecipeCollectionCreatedEventMeta implements Meta {
+public class EiffelTestExecutionRecipeCollectionCreatedEventMeta implements Meta
+{
 
     /**
      * 
@@ -46,8 +47,7 @@ public class EiffelTestExecutionRecipeCollectionCreatedEventMeta implements Meta
      */
     @SerializedName("version")
     @Expose
-    private EiffelTestExecutionRecipeCollectionCreatedEventMeta.Version version = EiffelTestExecutionRecipeCollectionCreatedEventMeta.Version
-            .fromValue("4.0.0");
+    private EiffelTestExecutionRecipeCollectionCreatedEventMeta.Version version = EiffelTestExecutionRecipeCollectionCreatedEventMeta.Version.fromValue("4.0.0");
     /**
      * 
      * (Required)
@@ -170,7 +170,7 @@ public class EiffelTestExecutionRecipeCollectionCreatedEventMeta implements Meta
         private final static Map<String, EiffelTestExecutionRecipeCollectionCreatedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelTestExecutionRecipeCollectionCreatedEventMeta.Type>();
 
         static {
-            for (EiffelTestExecutionRecipeCollectionCreatedEventMeta.Type c : values()) {
+            for (EiffelTestExecutionRecipeCollectionCreatedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -207,7 +207,7 @@ public class EiffelTestExecutionRecipeCollectionCreatedEventMeta implements Meta
         private final static Map<String, EiffelTestExecutionRecipeCollectionCreatedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelTestExecutionRecipeCollectionCreatedEventMeta.Version>();
 
         static {
-            for (EiffelTestExecutionRecipeCollectionCreatedEventMeta.Version c : values()) {
+            for (EiffelTestExecutionRecipeCollectionCreatedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteFinishedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteFinishedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelTestSuiteFinishedEvent extends Event {
+public class EiffelTestSuiteFinishedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteFinishedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteFinishedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelTestSuiteFinishedEventMeta implements Meta {
+public class EiffelTestSuiteFinishedEventMeta implements Meta
+{
 
     /**
      * 
@@ -46,8 +47,7 @@ public class EiffelTestSuiteFinishedEventMeta implements Meta {
      */
     @SerializedName("version")
     @Expose
-    private EiffelTestSuiteFinishedEventMeta.Version version = EiffelTestSuiteFinishedEventMeta.Version
-            .fromValue("3.0.0");
+    private EiffelTestSuiteFinishedEventMeta.Version version = EiffelTestSuiteFinishedEventMeta.Version.fromValue("3.0.0");
     /**
      * 
      * (Required)
@@ -170,7 +170,7 @@ public class EiffelTestSuiteFinishedEventMeta implements Meta {
         private final static Map<String, EiffelTestSuiteFinishedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelTestSuiteFinishedEventMeta.Type>();
 
         static {
-            for (EiffelTestSuiteFinishedEventMeta.Type c : values()) {
+            for (EiffelTestSuiteFinishedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -207,7 +207,7 @@ public class EiffelTestSuiteFinishedEventMeta implements Meta {
         private final static Map<String, EiffelTestSuiteFinishedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelTestSuiteFinishedEventMeta.Version>();
 
         static {
-            for (EiffelTestSuiteFinishedEventMeta.Version c : values()) {
+            for (EiffelTestSuiteFinishedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteFinishedEventOutcome.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteFinishedEventOutcome.java
@@ -58,16 +58,20 @@ public class EiffelTestSuiteFinishedEventOutcome {
     public enum Conclusion {
 
         @SerializedName("SUCCESSFUL")
-        SUCCESSFUL("SUCCESSFUL"), @SerializedName("FAILED")
-        FAILED("FAILED"), @SerializedName("ABORTED")
-        ABORTED("ABORTED"), @SerializedName("TIMED_OUT")
-        TIMED_OUT("TIMED_OUT"), @SerializedName("INCONCLUSIVE")
+        SUCCESSFUL("SUCCESSFUL"),
+        @SerializedName("FAILED")
+        FAILED("FAILED"),
+        @SerializedName("ABORTED")
+        ABORTED("ABORTED"),
+        @SerializedName("TIMED_OUT")
+        TIMED_OUT("TIMED_OUT"),
+        @SerializedName("INCONCLUSIVE")
         INCONCLUSIVE("INCONCLUSIVE");
         private final String value;
         private final static Map<String, EiffelTestSuiteFinishedEventOutcome.Conclusion> CONSTANTS = new HashMap<String, EiffelTestSuiteFinishedEventOutcome.Conclusion>();
 
         static {
-            for (EiffelTestSuiteFinishedEventOutcome.Conclusion c : values()) {
+            for (EiffelTestSuiteFinishedEventOutcome.Conclusion c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -99,14 +103,16 @@ public class EiffelTestSuiteFinishedEventOutcome {
     public enum Verdict {
 
         @SerializedName("PASSED")
-        PASSED("PASSED"), @SerializedName("FAILED")
-        FAILED("FAILED"), @SerializedName("INCONCLUSIVE")
+        PASSED("PASSED"),
+        @SerializedName("FAILED")
+        FAILED("FAILED"),
+        @SerializedName("INCONCLUSIVE")
         INCONCLUSIVE("INCONCLUSIVE");
         private final String value;
         private final static Map<String, EiffelTestSuiteFinishedEventOutcome.Verdict> CONSTANTS = new HashMap<String, EiffelTestSuiteFinishedEventOutcome.Verdict>();
 
         static {
-            for (EiffelTestSuiteFinishedEventOutcome.Verdict c : values()) {
+            for (EiffelTestSuiteFinishedEventOutcome.Verdict c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteStartedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteStartedEvent.java
@@ -19,7 +19,9 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelTestSuiteStartedEvent extends Event {
+public class EiffelTestSuiteStartedEvent
+    extends Event
+{
 
     /**
      * 

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteStartedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteStartedEventMeta.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class EiffelTestSuiteStartedEventMeta implements Meta {
+public class EiffelTestSuiteStartedEventMeta implements Meta
+{
 
     /**
      * 
@@ -46,8 +47,7 @@ public class EiffelTestSuiteStartedEventMeta implements Meta {
      */
     @SerializedName("version")
     @Expose
-    private EiffelTestSuiteStartedEventMeta.Version version = EiffelTestSuiteStartedEventMeta.Version
-            .fromValue("3.0.0");
+    private EiffelTestSuiteStartedEventMeta.Version version = EiffelTestSuiteStartedEventMeta.Version.fromValue("3.0.0");
     /**
      * 
      * (Required)
@@ -170,7 +170,7 @@ public class EiffelTestSuiteStartedEventMeta implements Meta {
         private final static Map<String, EiffelTestSuiteStartedEventMeta.Type> CONSTANTS = new HashMap<String, EiffelTestSuiteStartedEventMeta.Type>();
 
         static {
-            for (EiffelTestSuiteStartedEventMeta.Type c : values()) {
+            for (EiffelTestSuiteStartedEventMeta.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }
@@ -207,7 +207,7 @@ public class EiffelTestSuiteStartedEventMeta implements Meta {
         private final static Map<String, EiffelTestSuiteStartedEventMeta.Version> CONSTANTS = new HashMap<String, EiffelTestSuiteStartedEventMeta.Version>();
 
         static {
-            for (EiffelTestSuiteStartedEventMeta.Version c : values()) {
+            for (EiffelTestSuiteStartedEventMeta.Version c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/IntegrityProtection.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/IntegrityProtection.java
@@ -88,23 +88,34 @@ public class IntegrityProtection {
     public enum Alg {
 
         @SerializedName("HS256")
-        HS_256("HS256"), @SerializedName("HS384")
-        HS_384("HS384"), @SerializedName("HS512")
-        HS_512("HS512"), @SerializedName("RS256")
-        RS_256("RS256"), @SerializedName("RS384")
-        RS_384("RS384"), @SerializedName("RS512")
-        RS_512("RS512"), @SerializedName("ES256")
-        ES_256("ES256"), @SerializedName("ES384")
-        ES_384("ES384"), @SerializedName("ES512")
-        ES_512("ES512"), @SerializedName("PS256")
-        PS_256("PS256"), @SerializedName("PS384")
-        PS_384("PS384"), @SerializedName("PS512")
+        HS_256("HS256"),
+        @SerializedName("HS384")
+        HS_384("HS384"),
+        @SerializedName("HS512")
+        HS_512("HS512"),
+        @SerializedName("RS256")
+        RS_256("RS256"),
+        @SerializedName("RS384")
+        RS_384("RS384"),
+        @SerializedName("RS512")
+        RS_512("RS512"),
+        @SerializedName("ES256")
+        ES_256("ES256"),
+        @SerializedName("ES384")
+        ES_384("ES384"),
+        @SerializedName("ES512")
+        ES_512("ES512"),
+        @SerializedName("PS256")
+        PS_256("PS256"),
+        @SerializedName("PS384")
+        PS_384("PS384"),
+        @SerializedName("PS512")
         PS_512("PS512");
         private final String value;
         private final static Map<String, IntegrityProtection.Alg> CONSTANTS = new HashMap<String, IntegrityProtection.Alg>();
 
         static {
-            for (IntegrityProtection.Alg c : values()) {
+            for (IntegrityProtection.Alg c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/Location.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/Location.java
@@ -77,15 +77,18 @@ public class Location {
     public enum Type {
 
         @SerializedName("ARTIFACTORY")
-        ARTIFACTORY("ARTIFACTORY"), @SerializedName("NEXUS")
-        NEXUS("NEXUS"), @SerializedName("PLAIN")
-        PLAIN("PLAIN"), @SerializedName("OTHER")
+        ARTIFACTORY("ARTIFACTORY"),
+        @SerializedName("NEXUS")
+        NEXUS("NEXUS"),
+        @SerializedName("PLAIN")
+        PLAIN("PLAIN"),
+        @SerializedName("OTHER")
         OTHER("OTHER");
         private final String value;
         private final static Map<String, Location.Type> CONSTANTS = new HashMap<String, Location.Type>();
 
         static {
-            for (Location.Type c : values()) {
+            for (Location.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }

--- a/src/main/java/com/ericsson/eiffel/semantics/events/Trigger.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/Trigger.java
@@ -62,16 +62,20 @@ public class Trigger {
     public enum Type {
 
         @SerializedName("MANUAL")
-        MANUAL("MANUAL"), @SerializedName("EIFFEL_EVENT")
-        EIFFEL_EVENT("EIFFEL_EVENT"), @SerializedName("SOURCE_CHANGE")
-        SOURCE_CHANGE("SOURCE_CHANGE"), @SerializedName("TIMER")
-        TIMER("TIMER"), @SerializedName("OTHER")
+        MANUAL("MANUAL"),
+        @SerializedName("EIFFEL_EVENT")
+        EIFFEL_EVENT("EIFFEL_EVENT"),
+        @SerializedName("SOURCE_CHANGE")
+        SOURCE_CHANGE("SOURCE_CHANGE"),
+        @SerializedName("TIMER")
+        TIMER("TIMER"),
+        @SerializedName("OTHER")
         OTHER("OTHER");
         private final String value;
         private final static Map<String, Trigger.Type> CONSTANTS = new HashMap<String, Trigger.Type>();
 
         static {
-            for (Trigger.Type c : values()) {
+            for (Trigger.Type c: values()) {
                 CONSTANTS.put(c.value, c);
             }
         }


### PR DESCRIPTION
### Applicable Issues
Fixes #136 

### Description of the Change
`mvn clean install -P generate-events` was rerun to recreate all autogenerated files to get rid of the manual edits that have made it tedious to update the files. The copyright header is still being removed by the autogeneration so it's not perfect but keeping the file header intact is much more manageable than the other manualedits.

This commit doesn't introduce any functional changes. The only differences are from changes in intraline whitespace and newlines.

### Alternate Designs
None.

### Benefits
Easier to recreate the autogenerate files.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
