### PR TITLE
Add REST endpoint for listing available message protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+##2.2.1
+- Provided implementation for getProtocolEdition() method which returns the edition name
+- Uplifted eiffel-remrem-protocol-interface version from 2.1.1 to 2.1.2.
+
 ## 2.2.0
 - Updated schemas to match the Paris edition of the protocol.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
-##2.2.1
-- Provided implementation for getProtocolEdition() method which returns the edition name
-- Uplifted eiffel-remrem-protocol-interface version from 2.1.1 to 2.1.2.
 
 ## 2.2.0
 - Updated schemas to match the Paris edition of the protocol.
+- Provided implementation for getProtocolEdition() method which returns the edition name
+- Uplifted eiffel-remrem-protocol-interface version from 2.1.1 to 2.1.2.
 
 ## 2.1.1
 - Uplifted eiffel-remrem-parent version from 2.0.4 to 2.0.5.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <version>2.0.5</version>
     </parent>
     <artifactId>eiffel-remrem-semantics</artifactId>
-    <version>2.2.1</version>
+    <version>2.2.0</version>
     <packaging>jar</packaging>
     <properties>
         <eclipse.jgit.version>5.0.1.201806211838-r</eclipse.jgit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <version>2.0.5</version>
     </parent>
     <artifactId>eiffel-remrem-semantics</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <packaging>jar</packaging>
     <properties>
         <eclipse.jgit.version>5.0.1.201806211838-r</eclipse.jgit.version>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.github.eiffel-community</groupId>
             <artifactId>eiffel-remrem-protocol-interface</artifactId>
-            <version>2.1.1</version>
+            <version>2.1.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -185,6 +185,7 @@
                             <groupId>${project.groupId}</groupId>
                             <artifactId>${project.artifactId}</artifactId>
                             <semanticsVersion>${project.version}</semanticsVersion>
+                            <semanticsEditionName>Paris</semanticsEditionName>
                         </manifestEntries>
                     </archive>
                     <appendAssemblyId>false</appendAssemblyId>

--- a/src/main/java/com/ericsson/eiffel/remrem/semantics/SemanticsService.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/semantics/SemanticsService.java
@@ -471,14 +471,14 @@ public class SemanticsService implements MsgService {
 
     @Override
     public String getProtocolEdition() {
-        Enumeration<?> eNum;
+        Enumeration<?> manifestFileName;
         try {
-            eNum = Thread.currentThread()
+            manifestFileName = Thread.currentThread()
                          .getContextClassLoader()
                          .getResources(JarFile.MANIFEST_NAME);
-            while (eNum.hasMoreElements()) {
+            while (manifestFileName.hasMoreElements()) {
                 try {
-                    final URL url = (URL) eNum.nextElement();
+                    final URL url = (URL) manifestFileName.nextElement();
                     final InputStream inputStream = url.openStream();
                     if (inputStream != null) {
                         final Manifest manifest = new Manifest(inputStream);

--- a/src/main/java/com/ericsson/eiffel/remrem/semantics/SemanticsService.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/semantics/SemanticsService.java
@@ -48,12 +48,18 @@ import static com.ericsson.eiffel.remrem.semantics.EiffelEventType.TESTCASE_TRIG
 import static com.ericsson.eiffel.remrem.semantics.EiffelEventType.TESTSUITE_FINISHED;
 import static com.ericsson.eiffel.remrem.semantics.EiffelEventType.TESTSUITE_STARTED;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Named;
@@ -127,11 +133,13 @@ public class SemanticsService implements MsgService {
     private static final String DOMAIN_ID = "domainId";
     private static final String PROTOCOL = "eiffel";
     private static final String DOT = ".";
+    private static final String SEMANTICS_EDITION_NAME = "semanticsEditionName";
     private final ArrayList<String> supportedEventTypes = new ArrayList<String>();
     public static final Logger log = LoggerFactory.getLogger(SemanticsService.class);
     private Event event = new Event();
     public static String purlSerializer;
     private boolean purlSerializerFlag = false;
+    private static String editionName;
     private static Gson gson = new Gson();
     private static Map<EiffelEventType, Class<? extends Event>> eventTypes = SemanticsService.eventType();
 
@@ -459,5 +467,34 @@ public class SemanticsService implements MsgService {
         String serializer = source.getSerializer() == null ? purlSerializer : source.getSerializer();
         source.setSerializer(serializer);
         return source;
+    }
+
+    @Override
+    public String getProtocolEdition() {
+        Enumeration<?> eNum;
+        try {
+            eNum = Thread.currentThread()
+                         .getContextClassLoader()
+                         .getResources(JarFile.MANIFEST_NAME);
+            while (eNum.hasMoreElements()) {
+                try {
+                    final URL url = (URL) eNum.nextElement();
+                    final InputStream inputStream = url.openStream();
+                    if (inputStream != null) {
+                        final Manifest manifest = new Manifest(inputStream);
+                        final Attributes mainAttribs = manifest.getMainAttributes();
+                        final String edition = mainAttribs.getValue(SEMANTICS_EDITION_NAME);
+                        if (edition != null) {
+                            editionName = edition;
+                        }
+                    }
+                } catch (Exception e) {
+                    // Silently ignore wrong manifests on classpath?
+                }
+            }
+        } catch (IOException e) {
+            // Silently ignore wrong manifests on classpath?
+        }
+        return editionName;
     }
 }

--- a/src/main/java/com/ericsson/eiffel/remrem/semantics/SemanticsService.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/semantics/SemanticsService.java
@@ -471,14 +471,14 @@ public class SemanticsService implements MsgService {
 
     @Override
     public String getProtocolEdition() {
-        Enumeration<?> manifestFileName;
+        Enumeration<?> files;
         try {
-            manifestFileName = Thread.currentThread()
+            files = Thread.currentThread()
                          .getContextClassLoader()
                          .getResources(JarFile.MANIFEST_NAME);
-            while (manifestFileName.hasMoreElements()) {
+            while (files.hasMoreElements()) {
                 try {
-                    final URL url = (URL) manifestFileName.nextElement();
+                    final URL url = (URL) files.nextElement();
                     final InputStream inputStream = url.openStream();
                     if (inputStream != null) {
                         final Manifest manifest = new Manifest(inputStream);


### PR DESCRIPTION


### Applicable Issues

https://github.com/eiffel-community/eiffel-remrem-generate/issues/143#

### Description of the Change

Provided implementation for getProtocolEdition() abstract method. By using this method we can return message protocol edition name.

### Alternate Designs

### Benefits

Will get more understanding about the edition which we are using.

### Possible Drawbacks


### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Vishnu Alapati vishnu.alapati@tcs.com
