### PR TITLE
Implemented code changes to append copyright header to generated POJO classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.2.0
 - Updated schemas to match the Paris edition of the protocol.
+- After schema update process,implemented code changes to append copyright header to generated POJO classes.
 
 ## 2.1.1
 - Uplifted eiffel-remrem-parent version from 2.0.4 to 2.0.5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.2.0
 - Updated schemas to match the Paris edition of the protocol.
-- After schema update process,implemented code changes to append copyright header to generated POJO classes.
+- After schema update process,implemented code changes to prepend copyright header to generated POJO classes.
 
 ## 2.1.1
 - Uplifted eiffel-remrem-parent version from 2.0.4 to 2.0.5.

--- a/copyright_header.txt
+++ b/copyright_header.txt
@@ -1,0 +1,12 @@
+    Copyright 2018 Ericsson AB.
+    For a full list of individual contributors, please see the commit history.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <version>2.0.6</version>
     </parent>
     <artifactId>eiffel-remrem-semantics</artifactId>
-    <version>2.2.1</version>
+    <version>2.2.2</version>
     <packaging>jar</packaging>
     <properties>
         <eclipse.jgit.version>5.0.1.201806211838-r</eclipse.jgit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <packaging>jar</packaging>
     <properties>
         <eclipse.jgit.version>5.0.1.201806211838-r</eclipse.jgit.version>
+        <license.dir>${basedir}</license.dir>
     </properties>
     <repositories>
         <repository>
@@ -149,6 +150,30 @@
                                 <goals>
                                     <goal>generate</goal>
                                 </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.mycila.maven-license-plugin</groupId>
+                        <artifactId>maven-license-plugin</artifactId>
+                        <version>1.10.b1</version>
+                        <configuration>
+                            <header>${license.dir}/copyright_header.txt</header>
+                            <properties>
+                                <project>${project.name}</project>
+                                <founder>${project.organization.name}</founder>
+                                <year>${project.inceptionYear}</year>
+                            </properties>
+                            <includes>
+                                <include>src/main/java/</include>
+                            </includes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>format</goal>
+                                </goals>
+                                <phase>process-sources</phase>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -159,11 +159,6 @@
                         <version>1.10.b1</version>
                         <configuration>
                             <header>${license.dir}/copyright_header.txt</header>
-                            <properties>
-                                <project>${project.name}</project>
-                                <founder>${project.organization.name}</founder>
-                                <year>${project.inceptionYear}</year>
-                            </properties>
                             <includes>
                                 <include>src/main/java/</include>
                             </includes>

--- a/src/main/java/com/ericsson/eiffel/semantics/events/Author.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/Author.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/Batch.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/Batch.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/CcCompositeIdentifier.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/CcCompositeIdentifier.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/Change.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/Change.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/Constraint.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/Constraint.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/CustomData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/CustomData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/Dependency.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/Dependency.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityCanceledEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityCanceledEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityCanceledEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityCanceledEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityCanceledEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityCanceledEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityFinishedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityFinishedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityFinishedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityFinishedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityFinishedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityFinishedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityFinishedEventOutcome.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityFinishedEventOutcome.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.HashMap;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityStartedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityStartedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityStartedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityStartedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityStartedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityStartedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityTriggeredEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityTriggeredEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityTriggeredEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityTriggeredEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityTriggeredEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelActivityTriggeredEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertAcknowledgedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertAcknowledgedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertAcknowledgedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertAcknowledgedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertAcknowledgedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertAcknowledgedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertCeasedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertCeasedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertCeasedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertCeasedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertCeasedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertCeasedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertRaisedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertRaisedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertRaisedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertRaisedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertRaisedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAlertRaisedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAnnouncementPublishedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAnnouncementPublishedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAnnouncementPublishedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAnnouncementPublishedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAnnouncementPublishedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelAnnouncementPublishedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactCreatedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactCreatedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactCreatedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactCreatedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactCreatedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactCreatedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactDeployedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactDeployedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactDeployedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactDeployedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactDeployedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactDeployedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactPublishedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactPublishedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactPublishedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactPublishedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactPublishedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactPublishedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactReusedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactReusedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactReusedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactReusedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactReusedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelArtifactReusedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelCompositionDefinedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelCompositionDefinedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelCompositionDefinedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelCompositionDefinedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelCompositionDefinedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelCompositionDefinedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelConfidenceLevelModifiedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelConfidenceLevelModifiedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelConfidenceLevelModifiedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelConfidenceLevelModifiedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelConfidenceLevelModifiedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelConfidenceLevelModifiedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelEnvironmentDefinedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelEnvironmentDefinedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelEnvironmentDefinedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelEnvironmentDefinedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelEnvironmentDefinedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelEnvironmentDefinedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelFlowContextDefinedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelFlowContextDefinedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelFlowContextDefinedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelFlowContextDefinedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelFlowContextDefinedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelFlowContextDefinedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelIssueDefinedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelIssueDefinedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelIssueDefinedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelIssueDefinedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelIssueDefinedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelIssueDefinedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelIssueVerifiedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelIssueVerifiedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelIssueVerifiedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelIssueVerifiedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelIssueVerifiedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelIssueVerifiedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceAllocatedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceAllocatedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceAllocatedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceAllocatedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceAllocatedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceAllocatedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceDeployedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceDeployedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceDeployedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceDeployedEventData.java
@@ -1,18 +1,18 @@
-/*
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceDeployedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceDeployedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceDiscontinuedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceDiscontinuedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceDiscontinuedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceDiscontinuedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceDiscontinuedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceDiscontinuedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceReturnedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceReturnedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceReturnedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceReturnedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceReturnedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceReturnedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceStartedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceStartedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceStartedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceStartedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceStartedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceStartedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceStoppedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceStoppedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceStoppedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceStoppedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceStoppedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelServiceStoppedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelSourceChangeCreatedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelSourceChangeCreatedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelSourceChangeCreatedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelSourceChangeCreatedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelSourceChangeCreatedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelSourceChangeCreatedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelSourceChangeSubmittedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelSourceChangeSubmittedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelSourceChangeSubmittedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelSourceChangeSubmittedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelSourceChangeSubmittedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelSourceChangeSubmittedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseCanceledEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseCanceledEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseCanceledEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseCanceledEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseCanceledEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseCanceledEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseFinishedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseFinishedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseFinishedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseFinishedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseFinishedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseFinishedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseFinishedEventOutcome.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseFinishedEventOutcome.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseStartedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseStartedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseStartedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseStartedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseStartedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseStartedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseTriggeredEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseTriggeredEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseTriggeredEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseTriggeredEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseTriggeredEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestCaseTriggeredEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestExecutionRecipeCollectionCreatedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestExecutionRecipeCollectionCreatedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestExecutionRecipeCollectionCreatedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestExecutionRecipeCollectionCreatedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestExecutionRecipeCollectionCreatedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestExecutionRecipeCollectionCreatedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteFinishedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteFinishedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteFinishedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteFinishedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteFinishedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteFinishedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteFinishedEventOutcome.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteFinishedEventOutcome.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.HashMap;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteStartedEvent.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteStartedEvent.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteStartedEventData.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteStartedEventData.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteStartedEventMeta.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/EiffelTestSuiteStartedEventMeta.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/FileInformation.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/FileInformation.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/GitIdentifier.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/GitIdentifier.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/HgIdentifier.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/HgIdentifier.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/Host.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/Host.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/IntegrityProtection.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/IntegrityProtection.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.HashMap;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/Issuer.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/Issuer.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/Link.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/Link.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/LiveLog.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/LiveLog.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/Location.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/Location.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.HashMap;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/Metric.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/Metric.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/Parameter.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/Parameter.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/PersistentLog.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/PersistentLog.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/Recipe.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/Recipe.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/Security.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/Security.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/SelectionStrategy.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/SelectionStrategy.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/SequenceProtection.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/SequenceProtection.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/Source.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/Source.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/Submitter.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/Submitter.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/SvnIdentifier.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/SvnIdentifier.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/TestCase.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/TestCase.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import com.google.gson.annotations.Expose;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/Trigger.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/Trigger.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.HashMap;

--- a/src/main/java/com/ericsson/eiffel/semantics/events/Type.java
+++ b/src/main/java/com/ericsson/eiffel/semantics/events/Type.java
@@ -1,17 +1,18 @@
-/*
-    Copyright 2018 Ericsson AB.
-    For a full list of individual contributors, please see the commit history.
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+/**
+ *     Copyright 2018 Ericsson AB.
+ *     For a full list of individual contributors, please see the commit history.
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
 
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 package com.ericsson.eiffel.semantics.events;
 
 import java.util.HashMap;


### PR DESCRIPTION
Implemented code changes to append copyright header to generated POJO classes.

### Applicable Issues
 Schema update process removes copyright header from files #133 

### Description of the Change
After schema update process , added copyright header to generated POJO classes using  https://mvnrepository.com/artifact/com.mycila.maven-license-plugin/maven-license-plugin

### Alternate Designs


### Benefits
Using this plugin copyright header will be added only for the files  for which header is not present.

### Possible Drawbacks


### Sign-off


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: VaishnaviEnugala  vaishnavi.enugala@tcs.com
